### PR TITLE
Fixed paths in util/install.sh for iw

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -144,8 +144,9 @@ function mn_deps {
 function wifi_deps {
     echo "Installing Mininet-WiFi dependencies"
     $install hostapd iw wireless-tools python-numpy python-scipy pkg-config libnl-dev
-    cd iw
+    pushd $MININET_DIR/mininet-wifi/iw
     sudo make install
+    popd
 }
 
 # Install Mininet developer dependencies
@@ -549,8 +550,9 @@ function hostapd {
 function iw {
     echo "Installing iw..."
     $install iw wireless-tools python-numpy python-scipy pkg-config libnl-dev
-    cd mininet-wifi/iw
+    pushd $MININET_DIR/mininet-wifi/iw
     sudo make install
+    popd
 }
 
 


### PR DESCRIPTION
I had some errors in a script which provisions a VM with mininet-wifi. After some digging I figured out it was just an issue with paths when building the new iw dependency. I have seen in one place there was already an attempt to fix this but in another place it was still missing.

I decided to change both sites of the error with pushd/popd. Like that the functions do not have the side effect of a changed working directory, which is in line with all the other install functions.