### PR TITLE
Fixed wmediumd integration

### DIFF
--- a/examples/wmediumd_ibss_dynamic.py
+++ b/examples/wmediumd_ibss_dynamic.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 """
-This example shows how to use the wmediumd connector to prevent mac80211_hwsim radios reaching each other
+This example shows how to use the wmediumd connector to prevent mac80211_hwsim stations reaching each other
 
 author: Patrick Grosse (patrick.grosse@uni-muenster.de)
 """
@@ -9,7 +9,7 @@ author: Patrick Grosse (patrick.grosse@uni-muenster.de)
 from mininet.net import Mininet
 from mininet.cli import CLI
 from mininet.log import setLogLevel
-from mininet.wmediumdConnector import WmediumdConn, WmediumdIntfRef, WmediumdLink
+from mininet.wmediumdConnector import WmediumdConn, DynamicWmediumdIntfRef, WmediumdLink
 
 
 def topology():
@@ -32,9 +32,9 @@ def topology():
     net.build()
 
     print "*** Configure wmediumd"
-    sta1wlan0 = WmediumdIntfRef(sta1, sta1.defaultIntf())
-    sta2wlan0 = WmediumdIntfRef(sta2, sta2.defaultIntf())
-    sta3wlan0 = WmediumdIntfRef(sta3, sta3.defaultIntf())
+    sta1wlan0 = DynamicWmediumdIntfRef(sta1, sta1.defaultIntf())
+    sta2wlan0 = DynamicWmediumdIntfRef(sta2, sta2.defaultIntf())
+    sta3wlan0 = DynamicWmediumdIntfRef(sta3, sta3.defaultIntf())
 
     intfrefs = [sta1wlan0, sta2wlan0, sta3wlan0]
     links = [
@@ -42,8 +42,9 @@ def topology():
         WmediumdLink(sta2wlan0, sta1wlan0, 15),
         WmediumdLink(sta2wlan0, sta3wlan0, 15),
         WmediumdLink(sta3wlan0, sta2wlan0, 15)]
+    WmediumdConn.set_wmediumd_data(intfrefs, links)
 
-    WmediumdConn.connect_wmediumd(intfrefs, links)
+    WmediumdConn.connect_wmediumd()
 
     print "*** Running CLI"
     CLI(net)

--- a/examples/wmediumd_ibss_dynamic.py
+++ b/examples/wmediumd_ibss_dynamic.py
@@ -29,7 +29,7 @@ def topology():
     net.addHoc(sta3, ssid='adNet')
 
     print "*** Starting network"
-    net.build()
+    net.start()
 
     print "*** Configure wmediumd"
     sta1wlan0 = DynamicWmediumdIntfRef(sta1, sta1.defaultIntf())

--- a/examples/wmediumd_ibss_dynamic_intercept.py
+++ b/examples/wmediumd_ibss_dynamic_intercept.py
@@ -3,7 +3,7 @@
 """
 This example shows how to use the wmediumd connector to prevent mac80211_hwsim stations reaching each other
 
-The standard case should be covered in wmediumd_ibss_dynamic_intercept.py
+This is the standard example of using wmediumd with Mininet-Wifi
 
 author: Patrick Grosse (patrick.grosse@uni-muenster.de)
 """
@@ -25,18 +25,11 @@ def topology():
     sta2 = net.addStation('sta2')
     sta3 = net.addStation('sta3')
 
-    print "*** Creating links"
-    net.addHoc(sta1, ssid='adNet')
-    net.addHoc(sta2, ssid='adNet')
-    net.addHoc(sta3, ssid='adNet')
-
-    print "*** Starting network"
-    net.start()
-
     print "*** Configure wmediumd"
-    sta1wlan0 = DynamicWmediumdIntfRef(sta1, sta1.defaultIntf())
-    sta2wlan0 = DynamicWmediumdIntfRef(sta2, sta2.defaultIntf())
-    sta3wlan0 = DynamicWmediumdIntfRef(sta3, sta3.defaultIntf())
+    # This should be done right after the station has been initialized
+    sta1wlan0 = DynamicWmediumdIntfRef(sta1)
+    sta2wlan0 = DynamicWmediumdIntfRef(sta2)
+    sta3wlan0 = DynamicWmediumdIntfRef(sta3)
 
     intfrefs = [sta1wlan0, sta2wlan0, sta3wlan0]
     links = [
@@ -46,7 +39,15 @@ def topology():
         WmediumdLink(sta3wlan0, sta2wlan0, 15)]
     WmediumdConn.set_wmediumd_data(intfrefs, links)
 
-    WmediumdConn.connect_wmediumd_after_startup()
+    WmediumdConn.connect_wmediumd_on_startup()
+
+    print "*** Creating links"
+    net.addHoc(sta1, ssid='adNet')
+    net.addHoc(sta2, ssid='adNet')
+    net.addHoc(sta3, ssid='adNet')
+
+    print "*** Starting network"
+    net.start()
 
     print "*** Running CLI"
     CLI(net)

--- a/examples/wmediumd_ibss_static.py
+++ b/examples/wmediumd_ibss_static.py
@@ -44,7 +44,7 @@ def topology():
     net.addHoc(sta3, ssid='adNet')
 
     print "*** Starting network"
-    net.build()
+    net.start()
 
     print "*** Running CLI"
     CLI(net)

--- a/examples/wmediumd_ibss_static.py
+++ b/examples/wmediumd_ibss_static.py
@@ -3,6 +3,8 @@
 """
 This example shows how to use the wmediumd connector to prevent mac80211_hwsim stations reaching each other
 
+The standard case should be covered in wmediumd_ibss_dynamic_intercept.py
+
 author: Patrick Grosse (patrick.grosse@uni-muenster.de)
 """
 
@@ -31,7 +33,7 @@ def topology():
         WmediumdLink(sta3wlan0, sta2wlan0, 15)]
     WmediumdConn.set_wmediumd_data(intfrefs, links)
 
-    WmediumdConn.intercept_module_loading()
+    WmediumdConn.connect_wmediumd_on_startup()
 
     print "*** Creating nodes"
     sta1 = net.addStation('sta1')
@@ -59,3 +61,4 @@ def topology():
 if __name__ == '__main__':
     setLogLevel('info')
     topology()
+

--- a/examples/wmediumd_ibss_static.py
+++ b/examples/wmediumd_ibss_static.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+
+"""
+This example shows how to use the wmediumd connector to prevent mac80211_hwsim stations reaching each other
+
+author: Patrick Grosse (patrick.grosse@uni-muenster.de)
+"""
+
+from mininet.cli import CLI
+from mininet.log import setLogLevel
+from mininet.net import Mininet
+from mininet.wmediumdConnector import WmediumdConn, WmediumdLink, StaticWmediumdIntfRef
+
+
+def topology():
+    """Create a network. sta1 <--> sta2 <--> sta3"""
+
+    print "*** Network creation"
+    net = Mininet()
+
+    print "*** Configure wmediumd"
+    sta1wlan0 = StaticWmediumdIntfRef('sta1', 'sta1-wlan0', '02:00:00:00:00:00')
+    sta2wlan0 = StaticWmediumdIntfRef('sta2', 'sta2-wlan0', '02:00:00:00:01:00')
+    sta3wlan0 = StaticWmediumdIntfRef('sta3', 'sta3-wlan0', '02:00:00:00:02:00')
+
+    intfrefs = [sta1wlan0, sta2wlan0, sta3wlan0]
+    links = [
+        WmediumdLink(sta1wlan0, sta2wlan0, 15),
+        WmediumdLink(sta2wlan0, sta1wlan0, 15),
+        WmediumdLink(sta2wlan0, sta3wlan0, 15),
+        WmediumdLink(sta3wlan0, sta2wlan0, 15)]
+    WmediumdConn.set_wmediumd_data(intfrefs, links)
+
+    WmediumdConn.intercept_module_loading()
+
+    print "*** Creating nodes"
+    sta1 = net.addStation('sta1')
+    sta2 = net.addStation('sta2')
+    sta3 = net.addStation('sta3')
+
+    print "*** Creating links"
+    net.addHoc(sta1, ssid='adNet')
+    net.addHoc(sta2, ssid='adNet')
+    net.addHoc(sta3, ssid='adNet')
+
+    print "*** Starting network"
+    net.build()
+
+    print "*** Running CLI"
+    CLI(net)
+
+    print "*** Stopping wmediumd"
+    WmediumdConn.disconnect_wmediumd()
+
+    print "*** Stopping network"
+    net.stop()
+
+
+if __name__ == '__main__':
+    setLogLevel('info')
+    topology()

--- a/util/install.sh
+++ b/util/install.sh
@@ -695,9 +695,9 @@ function modprobe {
 
 # Script for installing wmediumd from git to /usr/bin/wmediumd
 function wmediumd {
-    echo "Installing wmediumd dependencies into $BUILD_DIR/wmediumd"
+    echo "Installing wmediumd sources into $BUILD_DIR/wmediumd"
     cd $BUILD_DIR
-    $install git make libevent-dev libconfig-dev libnl-3-dev
+    $install tmux git make libevent-dev libconfig-dev libnl-3-dev
     git clone https://github.com/bcopeland/wmediumd.git
     pushd $BUILD_DIR/wmediumd
     sudo make


### PR DESCRIPTION
* wmediumd is always started in a tmux session
* tmux is installed with wmediumd
* wmediumd service can be started before Mininet-Wifi Stations can do network activity

## This means two modes:
### Dynamic:
wmediumd is started after the network is started.

Pro: MAC addresses can be automatically retrieved
Con: tools like `iw station dump` obviously use some kind of cache

Example: `wmediumd_ibss_dynamic.py`

### Static:
wmediumd is started before the network is started.

Pro: Packets can be captured from the beginning
Con: MAC addresses have to be entered manually

Example: `wmediumd_ibss_static.py`