### PR TITLE
Improvements for the wmediumd connector

### DIFF
--- a/mininet/clean.py
+++ b/mininet/clean.py
@@ -137,8 +137,8 @@ class Cleanup( object ):
         killprocs( '.ssh/mn')
         sh( 'rm -f ~/.ssh/mn/*' )
 
-        info( "*** Killing wmediumd tmux session\n" )
-        sh( 'tmux kill-session -t mnwmd &> /dev/null' )
+        info( "*** Killing wmediumd\n" )
+        sh( 'pkill wmediumd' )
 
         # Call any additional cleanup code if necessary
         for callback in cls.callbacks:

--- a/mininet/clean.py
+++ b/mininet/clean.py
@@ -137,6 +137,9 @@ class Cleanup( object ):
         killprocs( '.ssh/mn')
         sh( 'rm -f ~/.ssh/mn/*' )
 
+        info( "*** Killing wmediumd tmux session\n" )
+        sh( 'tmux kill-session -t mnwmd &> /dev/null' )
+
         # Call any additional cleanup code if necessary
         for callback in cls.callbacks:
             callback()

--- a/mininet/wmediumdConnector.py
+++ b/mininet/wmediumdConnector.py
@@ -48,7 +48,7 @@ class WmediumdConn(object):
         :type links: list of WmediumdLink
         """
         if parameters is None:
-            parameters = ['-l', '5']
+            parameters = ['-l', '4']
         cls.intfrefs = intfrefs
         cls.links = links
         cls.executable = executable

--- a/util/install.sh
+++ b/util/install.sh
@@ -702,9 +702,8 @@ function wmediumd {
     $install tmux git make libevent-dev libconfig-dev libnl-3-dev
     git clone --depth=1 https://github.com/bcopeland/wmediumd.git
     pushd $BUILD_DIR/wmediumd
-    sudo make
+    sudo make install
     popd
-    sudo cp $BUILD_DIR/wmediumd/wmediumd/wmediumd /usr/bin/wmediumd
 }
 
 function all {

--- a/util/install.sh
+++ b/util/install.sh
@@ -700,7 +700,7 @@ function wmediumd {
     echo "Installing wmediumd sources into $BUILD_DIR/wmediumd"
     cd $BUILD_DIR
     $install git make libevent-dev libconfig-dev libnl-3-dev
-    git clone --depth=1 https://github.com/bcopeland/wmediumd.git
+    git clone --depth=1 -b mininet-wifi https://github.com/patgrosse/wmediumd.git
     pushd $BUILD_DIR/wmediumd
     sudo make install
     popd

--- a/util/install.sh
+++ b/util/install.sh
@@ -699,7 +699,7 @@ function modprobe {
 function wmediumd {
     echo "Installing wmediumd sources into $BUILD_DIR/wmediumd"
     cd $BUILD_DIR
-    $install tmux git make libevent-dev libconfig-dev libnl-3-dev
+    $install git make libevent-dev libconfig-dev libnl-3-dev
     git clone --depth=1 https://github.com/bcopeland/wmediumd.git
     pushd $BUILD_DIR/wmediumd
     sudo make install


### PR DESCRIPTION
* tmux is not required any longer
* log of wmediumd is not spammed and configurable
* log of wmediumd is a temporary file
* wmediumd is killed by cleanup