### PR TITLE
Fixes for using custom interface names

### DIFF
--- a/mininet/link.py
+++ b/mininet/link.py
@@ -817,7 +817,7 @@ class Association(Link):
         sta.params['rssi'][wlan] = -62
         sta.func[wlan] = 'adhoc'
         sta.intfs[wlan].setIP(sta.params['ip'][wlan])
-        sta.cmd('iw dev %s-wlan%s set type ibss' % (sta, wlan))
+        sta.cmd('iw dev %s set type ibss' % iface)
         sta.params['associatedTo'][wlan] = sta.params['ssid'][wlan]
         info("associating %s to %s...\n" % (iface, sta.params['ssid'][wlan]))
         sta.pexec('iw dev %s ibss join %s 2412' % (iface, \

--- a/mininet/wifiModule.py
+++ b/mininet/wifiModule.py
@@ -137,7 +137,7 @@ class module(object):
                             sta.cmd('ip link set %s name %s up' % (self.wlan_list[0], sta.params['wlan'][wlan]))
                             if sta.type != 'accessPoint':
                                 cls = TCLinkWireless
-                                cls(sta)
+                                cls(sta, intfName1=sta.params['wlan'][wlan])
                                 if sta.params['txpower'][wlan] != 20:
                                     sta.cmd('iwconfig %s txpower %s' % (sta.params['wlan'][wlan], sta.params['txpower'][wlan]))
                         if sta.type != 'accessPoint':


### PR DESCRIPTION
These small fixes are needed when using custom interface names. Before `configureWifiNodes()` is called, I wanted to use:
```python
sta1.params['wlan'][0] = 'custWifiIntf'
```
But I experienced some problems and I think I fixed them through these small fixes.

I hope I did not destroy anything. Using a few examples from the examples folder worked as expected.