### PR TITLE
Fixes for wmediumd examples

### DIFF
--- a/examples/wmediumd_ibss_dynamic.py
+++ b/examples/wmediumd_ibss_dynamic.py
@@ -25,6 +25,9 @@ def topology():
     sta2 = net.addStation('sta2')
     sta3 = net.addStation('sta3')
 
+    print "*** Configuring wifi nodes"
+    net.configureWifiNodes()
+
     print "*** Creating links"
     net.addHoc(sta1, ssid='adNet')
     net.addHoc(sta2, ssid='adNet')

--- a/examples/wmediumd_ibss_dynamic_intercept.py
+++ b/examples/wmediumd_ibss_dynamic_intercept.py
@@ -41,6 +41,9 @@ def topology():
 
     WmediumdConn.connect_wmediumd_on_startup()
 
+    print "*** Configuring wifi nodes"
+    net.configureWifiNodes()
+
     print "*** Creating links"
     net.addHoc(sta1, ssid='adNet')
     net.addHoc(sta2, ssid='adNet')

--- a/examples/wmediumd_ibss_static.py
+++ b/examples/wmediumd_ibss_static.py
@@ -40,6 +40,9 @@ def topology():
     sta2 = net.addStation('sta2')
     sta3 = net.addStation('sta3')
 
+    print "*** Configuring wifi nodes"
+    net.configureWifiNodes()
+
     print "*** Creating links"
     net.addHoc(sta1, ssid='adNet')
     net.addHoc(sta2, ssid='adNet')


### PR DESCRIPTION
Using `net.configureWifiNodes()` in wmediumd examples