### PR TITLE
Added additional package for wmediumd installation

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -699,7 +699,7 @@ function modprobe {
 function wmediumd {
     echo "Installing wmediumd sources into $BUILD_DIR/wmediumd"
     cd $BUILD_DIR
-    $install git make libevent-dev libconfig-dev libnl-3-dev
+    $install git make libevent-dev libconfig-dev libnl-3-dev libnl-genl-3-dev
     git clone --depth=1 -b mininet-wifi https://github.com/patgrosse/wmediumd.git
     pushd $BUILD_DIR/wmediumd
     sudo make install


### PR DESCRIPTION
libnl-genl-3-dev is required for wmediumd to compile and is in most cases automatically installed, but not every time