### PR TITLE
Multiple instances of MN-WiFi

### DIFF
--- a/examples/wmediumd_multiple_instances.py
+++ b/examples/wmediumd_multiple_instances.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python
+
+"""
+This example shows how to use the wmediumd connector to prevent mac80211_hwsim stations reaching each other
+
+This is the standard example of using wmediumd with Mininet-Wifi
+
+author: Patrick Grosse (patrick.grosse@uni-muenster.de)
+"""
+
+from mininet.net import Mininet
+from mininet.cli import CLI
+from mininet.log import setLogLevel
+from mininet.wmediumdConnector import DynamicWmediumdIntfRef, WmediumdLink, WmediumdConnector
+
+
+def topology():
+    """Create a network. sta1 <--> sta2 <--> sta3"""
+
+    print "*** Network creation"
+    net = Mininet()
+
+    print "*** Creating nodes"
+    sta1 = net.addStation('sta1')
+    sta2 = net.addStation('sta2')
+    sta3 = net.addStation('sta3')
+
+    print "*** Configure wmediumd"
+    # This should be done right after the station has been initialized
+    sta1wlan0 = DynamicWmediumdIntfRef(sta1)
+    sta2wlan0 = DynamicWmediumdIntfRef(sta2)
+    sta3wlan0 = DynamicWmediumdIntfRef(sta3)
+
+    intfrefs = [sta1wlan0, sta2wlan0, sta3wlan0]
+    links = [
+        WmediumdLink(sta1wlan0, sta2wlan0, 15),
+        WmediumdLink(sta2wlan0, sta1wlan0, 15),
+        WmediumdLink(sta2wlan0, sta3wlan0, 15),
+        WmediumdLink(sta3wlan0, sta2wlan0, 15)]
+
+    print "*** Configuring wifi nodes"
+    net.configureWifiNodes()
+
+    print "*** Creating links"
+    net.addHoc(sta1, ssid='adNet')
+    net.addHoc(sta2, ssid='adNet')
+    net.addHoc(sta3, ssid='adNet')
+
+    print "*** Starting network"
+    WmediumdConnector.connect()
+    for intfref in intfrefs:
+        WmediumdConnector.register_interface(intfref.get_intf_mac())
+
+    for link in links:
+        WmediumdConnector.update_link(link)
+
+    net.start()
+
+    print "*** Running CLI"
+    CLI(net)
+
+    print "*** Stopping wmediumd"
+    for intfref in intfrefs:
+        WmediumdConnector.unregister_interface(intfref.get_intf_mac())
+
+    print "*** Stopping network"
+    net.stop()
+
+
+if __name__ == '__main__':
+    setLogLevel('info')
+    topology()

--- a/mininet/clean.py
+++ b/mininet/clean.py
@@ -103,14 +103,11 @@ class Cleanup(object):
 
         if glob.glob("*.apconf"):
             os.system('rm *.apconf')
-	if glob.glob("*wifiDirect.conf"):
+        if glob.glob("*wifiDirect.conf"):
             os.system('rm *wifiDirect.conf')
 
         try:
-            h = subprocess.check_output("ps -aux | grep -ic \'wpa_supplicant -B -Dnl80211\'",
-                                                          shell=True)
-            if h >= 2:
-                os.system('pkill -f \'wpa_supplicant -B -Dnl80211\'')
+            os.system('pkill -f \'wpa_supplicant -B -Dnl80211\'')
         except:
             pass
 

--- a/mininet/link.py
+++ b/mininet/link.py
@@ -23,6 +23,8 @@ TCIntf: interface with bandwidth limiting and delay via tc
 
 Link: basic link class for creating veth pairs
 """
+import os
+
 import re
 from time import time
 
@@ -950,8 +952,9 @@ class Association(Link):
             passwd = ap.params['passwd'][0]
         else:
             passwd = sta.params['passwd'][wlan]
-        sta.cmd("wpa_supplicant -B -Dnl80211 -i %s-wlan%s -c <(wpa_passphrase \"%s\" \"%s\")" \
-                % (sta, wlan, ap.params['ssid'][0], passwd))
+        pidfile = "mn%d_%s_%s_wpa.pid" % (os.getpid(), sta.name, wlan)
+        sta.cmd("wpa_supplicant -B -Dnl80211 -P %s -i %s-wlan%s -c <(wpa_passphrase \"%s\" \"%s\")"
+                % (pidfile, sta, wlan, ap.params['ssid'][0], passwd))
 
     @classmethod
     def associate_wep(self, sta, ap, wlan):

--- a/mininet/net.py
+++ b/mininet/net.py
@@ -730,8 +730,8 @@ class Mininet(object):
             \ndevice_type=1-0050F204-1\
             \np2p_no_group_iface=1' % (sta)
         confname = "mn%d_%s_wifiDirect.conf" % (os.getpid(), sta)
-        apcommand = cmd + ("\' > %s" % confname)
-        os.system(apcommand)
+        cmd = cmd + ("\' > %s" % confname)
+        os.system(cmd)
         sta.cmd('wpa_supplicant -B -Dnl80211 -c%s -i%s-wlan0 -d' % (confname, sta))
 
         value = deviceDataRate(sta=sta, wlan=wlan)

--- a/mininet/net.py
+++ b/mininet/net.py
@@ -729,9 +729,10 @@ class Mininet(object):
             \ndevice_name=%s\
             \ndevice_type=1-0050F204-1\
             \np2p_no_group_iface=1' % (sta)
-        apcommand = cmd + ("\' > %s_wifiDirect.conf" % sta)
+        confname = "mn%d_%s_wifiDirect.conf" % (os.getpid(), sta)
+        apcommand = cmd + ("\' > %s" % confname)
         os.system(apcommand)
-        sta.cmd('wpa_supplicant -B -Dnl80211 -i%s-wlan0 -d -c%s_wifiDirect.conf' % (sta, sta))
+        sta.cmd('wpa_supplicant -B -Dnl80211 -c%s -i%s-wlan0 -d' % (confname, sta))
 
         value = deviceDataRate(sta=sta, wlan=wlan)
         self.bw = value.rate

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1537,9 +1537,10 @@ class AccessPoint(Switch):
             iface = ap.params.get('phywlan')
             ap.cmd('ifconfig %s down' % iface)
             ap.cmd('ifconfig %s up' % iface)
-        content = cmd + ("\' > %s.apconf" % iface)
+        apconfname = "mn%d_%s.apconf" % (os.getpid(), iface)
+        content = cmd + ("\' > %s" % apconfname)
         ap.cmd(content)
-        cmd = ("hostapd -B %s.apconf" % iface)
+        cmd = ("hostapd -B %s" % apconfname)
         try:
             ap.cmd(cmd)
         except:

--- a/mininet/wifiMobility.py
+++ b/mininet/wifiMobility.py
@@ -180,7 +180,8 @@ class mobility (object):
         :param wlan: wlan ID
         """
         passwd = self.verifyPasswd(sta, ap, wlan)
-        os.system('pkill -f \'wpa_supplicant -B -Dnl80211 -i %s\'' % sta.params['wlan'][wlan])
+        confname = "mn%d_%s_wifiDirect.conf" % (os.getpid(), sta.name)
+        os.system('pkill -f \'wpa_supplicant -B -Dnl80211 -c%s\'' % confname)
         sta.cmd("wpa_supplicant -B -Dnl80211 -i %s -c <(wpa_passphrase \"%s\" \"%s\")" \
                                              % (sta.params['wlan'][wlan], ap.params['ssid'][0], passwd))
         self.updateAssociation(sta, ap, wlan)    

--- a/mininet/wifiMobility.py
+++ b/mininet/wifiMobility.py
@@ -180,10 +180,10 @@ class mobility (object):
         :param wlan: wlan ID
         """
         passwd = self.verifyPasswd(sta, ap, wlan)
-        confname = "mn%d_%s_wifiDirect.conf" % (os.getpid(), sta.name)
-        os.system('pkill -f \'wpa_supplicant -B -Dnl80211 -c%s\'' % confname)
-        sta.cmd("wpa_supplicant -B -Dnl80211 -i %s -c <(wpa_passphrase \"%s\" \"%s\")" \
-                                             % (sta.params['wlan'][wlan], ap.params['ssid'][0], passwd))
+        pidfile = "mn%d_%s_%s_wpa.pid" % (os.getpid(), sta.name, wlan)
+        os.system('pkill -f \'wpa_supplicant -B -Dnl80211 -i %s -P %s\'' % (sta.params['wlan'][wlan], pidfile))
+        sta.cmd("wpa_supplicant -B -Dnl80211 -i %s -P %s -c <(wpa_passphrase \"%s\" \"%s\")"
+                % (sta.params['wlan'][wlan], pidfile, ap.params['ssid'][0], passwd))
         self.updateAssociation(sta, ap, wlan)    
     
     @classmethod

--- a/mininet/wifiMobility.py
+++ b/mininet/wifiMobility.py
@@ -181,9 +181,9 @@ class mobility (object):
         """
         passwd = self.verifyPasswd(sta, ap, wlan)
         pidfile = "mn%d_%s_%s_wpa.pid" % (os.getpid(), sta.name, wlan)
-        os.system('pkill -f \'wpa_supplicant -B -Dnl80211 -i %s -P %s\'' % (sta.params['wlan'][wlan], pidfile))
-        sta.cmd("wpa_supplicant -B -Dnl80211 -i %s -P %s -c <(wpa_passphrase \"%s\" \"%s\")"
-                % (sta.params['wlan'][wlan], pidfile, ap.params['ssid'][0], passwd))
+        os.system('pkill -f \'wpa_supplicant -B -Dnl80211 -P %s -i %s\'' % (pidfile, sta.params['wlan'][wlan]))
+        sta.cmd("wpa_supplicant -B -Dnl80211 -P %s -i %s -c <(wpa_passphrase \"%s\" \"%s\")"
+                % (pidfile, sta.params['wlan'][wlan], ap.params['ssid'][0], passwd))
         self.updateAssociation(sta, ap, wlan)    
     
     @classmethod

--- a/mininet/wifiModule.py
+++ b/mininet/wifiModule.py
@@ -93,19 +93,13 @@ class module(object):
             
         try:
             confnames = "mn%d_" % os.getpid()
-            h = subprocess.check_output("ps -aux | grep -ic \'wpa_supplicant -B -Dnl80211 -c%s\'" % confnames,
-                                        shell=True)
-            if h >= 2:
-                os.system('pkill -f \'wpa_supplicant -B -Dnl80211 -c%s\'' % confnames)
+            os.system('pkill -f \'wpa_supplicant -B -Dnl80211 -c%s\'' % confnames)
         except:
             pass
 
         try:
             pidfiles = "mn%d_" % os.getpid()
-            h = subprocess.check_output("ps -aux | grep -ic \'wpa_supplicant -B -Dnl80211 -P %s\'" % pidfiles,
-                                        shell=True)
-            if h >= 2:
-                os.system('pkill -f \'wpa_supplicant -B -Dnl80211 -P %s\'' % pidfiles)
+            os.system('pkill -f \'wpa_supplicant -B -Dnl80211 -P %s\'' % pidfiles)
         except:
             pass
 

--- a/mininet/wifiModule.py
+++ b/mininet/wifiModule.py
@@ -6,7 +6,7 @@ import glob
 import os
 import subprocess
 import re
-from mininet.log import debug, info
+from mininet.log import debug, error, info
 
 class module(object):
     """ wireless module """
@@ -46,15 +46,15 @@ class module(object):
             p = subprocess.Popen(["hwsim_mgmt", "-c", "-n", self.prefix + ("%02d" % i)], stdin=subprocess.PIPE,
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE, bufsize=-1)
-            output, error = p.communicate()
+            output, err_out = p.communicate()
             if p.returncode == 0:
                 m = re.search("ID (\d+)", output)
-                print "Created mac80211_hwsim device with ID", m.group(1)
+                debug("Created mac80211_hwsim device with ID %d" % m.group(1))
                 self.hwsim_ids.append(m.group(1))
             else:
-                print "Error on creating mac80211_hwsim device with name", self.prefix + ("%02d" % i)
-                print "Output:", output
-                print "Error:", error
+                error("Error on creating mac80211_hwsim device with name %s" % (self.prefix + ("%02d" % i)))
+                error("Output: %s" % output)
+                error("Error: %s" % err_out)
 
     @classmethod
     def stop(self):
@@ -67,14 +67,14 @@ class module(object):
         for hwsim_id in self.hwsim_ids:
             p = subprocess.Popen(["hwsim_mgmt", "-d", hwsim_id], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE, bufsize=-1)
-            output, error = p.communicate()
+            output, err_out = p.communicate()
             if p.returncode == 0:
                 m = re.search("ID (\d+)", output)
-                print "Deleted mac80211_hwsim device with ID", m.group(1)
+                debug("Deleted mac80211_hwsim device with ID %d" % m.group(1))
             else:
-                print "Error on deleting mac80211_hwsim device with ID", hwsim_id
-                print "Output:", output
-                print "Error:", error
+                error("Error on deleting mac80211_hwsim device with ID %d" % hwsim_id)
+                error("Output: %s" % output)
+                error("Error: %s" % err_out)
 
         try:
             (subprocess.check_output("lsmod | grep ifb",

--- a/mininet/wifiModule.py
+++ b/mininet/wifiModule.py
@@ -87,7 +87,7 @@ class module(object):
             h = subprocess.check_output("ps -aux | grep -ic \'hostapd\'",
                                                           shell=True)
             if h >= 2:
-                os.system('pkill -f \'hostapd\' -B mn%d' % os.getpid())
+                os.system('pkill -f \'hostapd -B mn%d\'' % os.getpid())
         except:
             pass 
             

--- a/mininet/wifiModule.py
+++ b/mininet/wifiModule.py
@@ -5,13 +5,16 @@ author: Ramon Fontes (ramonrf@dca.fee.unicamp.br)
 import glob
 import os
 import subprocess
+import re
 from mininet.log import debug, info
 
 class module(object):
     """ wireless module """
 
     wlan_list = []
-    
+    hwsim_ids = []
+    prefix = ""
+
     @classmethod
     def loadModule(self, wifiRadios, alternativeModule=''):
         """ Load WiFi Module 
@@ -20,11 +23,37 @@ class module(object):
         :param alternativeModule: dir of a mac80211_hwsim alternative module
         """
         if alternativeModule == '':
-            os.system('modprobe mac80211_hwsim radios=%s' % wifiRadios)
-            debug('Loading %s virtual interfaces\n' % wifiRadios)
+            os.system('modprobe mac80211_hwsim radios=0')
         else:
-            os.system('insmod %s radios=%s' % (alternativeModule, wifiRadios))
-            debug('Loading %s virtual interfaces\n' % wifiRadios)
+            os.system('insmod %s radios=0' % alternativeModule)
+
+        debug('Loading %s virtual interfaces\n' % wifiRadios)
+        # generate prefix
+        phys = subprocess.check_output("find /sys/kernel/debug/ieee80211 -name hwsim | cut -d/ -f 6 | sort",
+                                       shell=True).split("\n")
+        num = 0
+        numokay = False
+        self.prefix = ""
+        while not numokay:
+            self.prefix = "mn%02ds" % num
+            for phy in phys:
+                if phy.startswith(self.prefix):
+                    num += 1
+                    continue
+            numokay = True
+        for i in range(0, wifiRadios):
+            p = subprocess.Popen(["hwsim_mgmt", "-c", "-n", self.prefix + ("%02d" % i)], stdin=subprocess.PIPE,
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE, bufsize=-1)
+            output, error = p.communicate()
+            if p.returncode == 0:
+                m = re.search("ID (\d+)", output)
+                print "Created mac80211_hwsim device with ID", m.group(1)
+                self.hwsim_ids.append(m.group(1))
+            else:
+                print "Error on creating mac80211_hwsim device with name", self.prefix + ("%02d" % i)
+                print "Output:", output
+                print "Error:", error
 
     @classmethod
     def stop(self):
@@ -34,13 +63,18 @@ class module(object):
         if glob.glob("*wifiDirect.conf"):
             os.system('rm *wifiDirect.conf')
 
-        try:
-            subprocess.check_output("lsmod | grep mac80211_hwsim",
-                                                          shell=True)
-            os.system('rmmod mac80211_hwsim')
-        except:
-            pass
-        
+        for hwsim_id in self.hwsim_ids:
+            p = subprocess.Popen(["hwsim_mgmt", "-d", hwsim_id], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE, bufsize=-1)
+            output, error = p.communicate()
+            if p.returncode == 0:
+                m = re.search("ID (\d+)", output)
+                print "Deleted mac80211_hwsim device with ID", m.group(1)
+            else:
+                print "Error on deleting mac80211_hwsim device with ID", hwsim_id
+                print "Output:", output
+                print "Error:", error
+
         try:
             (subprocess.check_output("lsmod | grep ifb",
                                                           shell=True))
@@ -62,7 +96,7 @@ class module(object):
             if h >= 2:
                 os.system('pkill -f \'wpa_supplicant -B -Dnl80211\'')
         except:
-            pass 
+            pass
 
     @classmethod
     def start(self, nodes, wifiRadios, alternativeModule='', **params):
@@ -73,22 +107,16 @@ class module(object):
         :param alternativeModule: dir of a mac80211_hwsim alternative module
         :param **params: ifb -  Intermediate Functional Block device
         """
-        """kill hostapd and mac80211_hwsim if they are already running"""
+        """kill hostapd if it is already running"""
         try:
             h = subprocess.check_output("ps -aux | grep -ic \'hostapd\'",
                                                           shell=True)
             if h >= 2:
                 os.system('pkill -f \'hostapd\'')
         except:
-            pass 
-        try:
-            (subprocess.check_output("lsmod | grep mac80211_hwsim",
-                                                          shell=True))
-            os.system('rmmod mac80211_hwsim')
-        except:
             pass
 
-        physicalWlans = self.getPhysicalWlan()  # Gets Phisical Wlan(s)
+        physicalWlans = self.getPhysicalWlan()  # Gets Physical Wlan(s)
         self.loadModule(wifiRadios, alternativeModule)  # Initatilize WiFi Module
         phys = self.getPhy()  # Get Phy Interfaces
         module.assignIface(nodes, physicalWlans, phys, **params) # iface assign
@@ -105,8 +133,9 @@ class module(object):
     @classmethod
     def getPhy(self):
         """Gets all phys after starting the wireless module"""
-        phy = subprocess.check_output("find /sys/kernel/debug/ieee80211 -name hwsim | cut -d/ -f 6 | sort",
-                                                             shell=True).split("\n")
+        phy = subprocess.check_output(
+            "find /sys/kernel/debug/ieee80211 -regex \".*/%s.*/hwsim\" | cut -d/ -f 6 | sort" % self.prefix,
+            shell=True).split("\n")
         phy.pop()
         phy.sort(key=len, reverse=False)
         return phy

--- a/mininet/wifiModule.py
+++ b/mininet/wifiModule.py
@@ -36,11 +36,12 @@ class module(object):
         self.prefix = ""
         while not numokay:
             self.prefix = "mn%02ds" % num
+            numokay = True
             for phy in phys:
                 if phy.startswith(self.prefix):
                     num += 1
-                    continue
-            numokay = True
+                    numokay = False
+                    break
         for i in range(0, wifiRadios):
             p = subprocess.Popen(["hwsim_mgmt", "-c", "-n", self.prefix + ("%02d" % i)], stdin=subprocess.PIPE,
                                  stdout=subprocess.PIPE,

--- a/mininet/wifiModule.py
+++ b/mininet/wifiModule.py
@@ -92,11 +92,20 @@ class module(object):
             pass 
             
         try:
-            confnames = "mn%d" % os.getpid()
+            confnames = "mn%d_" % os.getpid()
             h = subprocess.check_output("ps -aux | grep -ic \'wpa_supplicant -B -Dnl80211 -c%s\'" % confnames,
-                                                          shell=True)
+                                        shell=True)
             if h >= 2:
                 os.system('pkill -f \'wpa_supplicant -B -Dnl80211 -c%s\'' % confnames)
+        except:
+            pass
+
+        try:
+            pidfiles = "mn%d_" % os.getpid()
+            h = subprocess.check_output("ps -aux | grep -ic \'wpa_supplicant -B -Dnl80211 -P %s\'" % pidfiles,
+                                        shell=True)
+            if h >= 2:
+                os.system('pkill -f \'wpa_supplicant -B -Dnl80211 -P %s\'' % pidfiles)
         except:
             pass
 

--- a/mininet/wifiModule.py
+++ b/mininet/wifiModule.py
@@ -87,7 +87,7 @@ class module(object):
             h = subprocess.check_output("ps -aux | grep -ic \'hostapd\'",
                                                           shell=True)
             if h >= 2:
-                os.system('pkill -f \'hostapd\'')
+                os.system('pkill -f \'hostapd\' -B mn%d' % os.getpid())
         except:
             pass 
             

--- a/mininet/wifiModule.py
+++ b/mininet/wifiModule.py
@@ -92,10 +92,11 @@ class module(object):
             pass 
             
         try:
-            h = subprocess.check_output("ps -aux | grep -ic \'wpa_supplicant -B -Dnl80211\'",
+            confnames = "mn%d" % os.getpid()
+            h = subprocess.check_output("ps -aux | grep -ic \'wpa_supplicant -B -Dnl80211 -c%s\'" % confnames,
                                                           shell=True)
             if h >= 2:
-                os.system('pkill -f \'wpa_supplicant -B -Dnl80211\'')
+                os.system('pkill -f \'wpa_supplicant -B -Dnl80211 -c%s\'' % confnames)
         except:
             pass
 

--- a/mininet/wifiModule.py
+++ b/mininet/wifiModule.py
@@ -49,12 +49,12 @@ class module(object):
             output, err_out = p.communicate()
             if p.returncode == 0:
                 m = re.search("ID (\d+)", output)
-                debug("Created mac80211_hwsim device with ID %d" % m.group(1))
+                debug("\nCreated mac80211_hwsim device with ID %s" % m.group(1))
                 self.hwsim_ids.append(m.group(1))
             else:
-                error("Error on creating mac80211_hwsim device with name %s" % (self.prefix + ("%02d" % i)))
-                error("Output: %s" % output)
-                error("Error: %s" % err_out)
+                error("\nError on creating mac80211_hwsim device with name %s" % (self.prefix + ("%02d" % i)))
+                error("\nOutput: %s" % output)
+                error("\nError: %s" % err_out)
 
     @classmethod
     def stop(self):
@@ -70,11 +70,11 @@ class module(object):
             output, err_out = p.communicate()
             if p.returncode == 0:
                 m = re.search("ID (\d+)", output)
-                debug("Deleted mac80211_hwsim device with ID %d" % m.group(1))
+                debug("\nDeleted mac80211_hwsim device with ID %s" % m.group(1))
             else:
-                error("Error on deleting mac80211_hwsim device with ID %d" % hwsim_id)
-                error("Output: %s" % output)
-                error("Error: %s" % err_out)
+                error("\nError on deleting mac80211_hwsim device with ID %d" % hwsim_id)
+                error("\nOutput: %s" % output)
+                error("\nError: %s" % err_out)
 
         try:
             (subprocess.check_output("lsmod | grep ifb",

--- a/util/install.sh
+++ b/util/install.sh
@@ -143,8 +143,12 @@ function mn_deps {
 # Install Mininet-WiFi deps
 function wifi_deps {
     echo "Installing Mininet-WiFi dependencies"
-    $install wireless-tools python-numpy python-scipy pkg-config python-matplotlib libnl-3-dev libnl-genl-3-dev libssl-dev git make libevent-dev
-    pushd $MININET_DIR/mininet-wifi/hostapd/hostapd
+    $install wireless-tools python-numpy python-scipy pkg-config python-matplotlib libnl-3-dev libnl-genl-3-dev libssl-dev make libevent-dev
+    pushd $MININET_DIR/mininet-wifi
+    git submodule update --init --recursive
+    pushd $MININET_DIR/mininet-wifi/hostap
+    patch -p0 < $MININET_DIR/mininet-wifi/util/hostap-patches/config.patch
+    pushd $MININET_DIR/mininet-wifi/hostap/hostapd
     cp defconfig .config
     sudo make && make install
     pushd $MININET_DIR/mininet-wifi/hostap/wpa_supplicant

--- a/util/install.sh
+++ b/util/install.sh
@@ -143,12 +143,8 @@ function mn_deps {
 # Install Mininet-WiFi deps
 function wifi_deps {
     echo "Installing Mininet-WiFi dependencies"
-    $install wireless-tools python-numpy python-scipy pkg-config python-matplotlib libnl-3-dev libnl-genl-3-dev libssl-dev
-    pushd $MININET_DIR/mininet-wifi
-    git submodule update --init --recursive
-    pushd $MININET_DIR/mininet-wifi/hostap
-    patch -p0 < $MININET_DIR/mininet-wifi/util/hostap-patches/config.patch
-    pushd $MININET_DIR/mininet-wifi/hostap/hostapd
+    $install wireless-tools python-numpy python-scipy pkg-config python-matplotlib libnl-3-dev libnl-genl-3-dev libssl-dev git make libevent-dev
+    pushd $MININET_DIR/mininet-wifi/hostapd/hostapd
     cp defconfig .config
     sudo make && make install
     pushd $MININET_DIR/mininet-wifi/hostap/wpa_supplicant
@@ -156,6 +152,10 @@ function wifi_deps {
     sudo make && make install
     pushd $MININET_DIR/mininet-wifi/iw
     sudo make && make install
+    cd $BUILD_DIR
+    git clone --depth=1 https://github.com/patgrosse/mac80211_hwsim_mgmt.git
+    pushd $BUILD_DIR/mac80211_hwsim_mgmt
+    sudo make install
     #popd
 }
 


### PR DESCRIPTION
These changes use [mac80211_hwsim_mgmt](https://github.com/patgrosse/mac80211_hwsim_mgmt) to make multiple instances of MN-WiFi possible.

ToDo:
* how should **hostapd** be handled?
  * Update: multiple instances possible, but: ap interfaces are in root namespace => conflicting names
* how should **wpa_supplicant** be handled?
  * Update: multiple instances possible, but: could not test my changes because the wifiDirect.py example was not working, see also issue #25 
* how should **ifb** be handled?