### PR TITLE
Add default class type for Accesspoint

### DIFF
--- a/mininet/net.py
+++ b/mininet/net.py
@@ -162,6 +162,7 @@ class Mininet(object):
         self.switch = switch        
         self.host = host
         self.station = station
+	self.accesspoint= accesspoint
         self.car = car
         self.controller = controller
         self.link = link
@@ -427,7 +428,7 @@ class Mininet(object):
         defaults.update(params)
         
         if not cls:
-            cls = self.switch
+            cls = self.accesspoint
         if cls == OVSKernelSwitch:
             cls = OVSAP
         elif cls == UserSwitch:

--- a/mininet/net.py
+++ b/mininet/net.py
@@ -136,7 +136,7 @@ class Mininet(object):
     "Network emulation with hosts spawned in network namespaces."
 
     def __init__(self, topo=None, switch=OVSKernelSwitch, car=Car, station=Station, host=Host, isWiFi=False,
-                  controller=DefaultController, link=Link, intf=Intf,
+                  controller=DefaultController,accesspoint=OVSAP, link=Link, intf=Intf,
                   build=True, xterms=False, cleanup=False, ipBase='10.0.0.0/8',
                   inNamespace=False, autoSetMacs=False, autoStaticArp=False, autoPinCpus=False,
                   listenPort=None, waitConnected=False, ssid="new-ssid", mode="g", channel="6"):

--- a/mininet/net.py
+++ b/mininet/net.py
@@ -162,7 +162,7 @@ class Mininet(object):
         self.switch = switch        
         self.host = host
         self.station = station
-	self.accesspoint= accesspoint
+	self.accessPoint= accessPoint
         self.car = car
         self.controller = controller
         self.link = link


### PR DESCRIPTION
add default class type for the accesspoint of type OVSAP instead of switch default type in addAccessPoint() method.
