### PR TITLE
Installing patch in install.sh

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -149,7 +149,7 @@ function mn_deps {
 # Install Mininet-WiFi deps
 function wifi_deps {
     echo "Installing Mininet-WiFi dependencies"
-    $install wireless-tools python-numpy python-scipy pkg-config python-matplotlib libnl-3-dev libnl-genl-3-dev libssl-dev make libevent-dev
+    $install wireless-tools python-numpy python-scipy pkg-config python-matplotlib libnl-3-dev libnl-genl-3-dev libssl-dev make libevent-dev patch
     pushd $MININET_DIR/mininet-wifi
     git submodule update --init --recursive
     pushd $MININET_DIR/mininet-wifi/hostap
@@ -185,7 +185,7 @@ function mn_dev {
 function of {
     echo "Installing OpenFlow reference implementation..."
     cd $BUILD_DIR
-    $install autoconf automake libtool make gcc
+    $install autoconf automake libtool make gcc patch
     if [ "$DIST" = "Fedora" ]; then
         $install git pkgconfig glibc-devel
     else
@@ -571,7 +571,7 @@ function pox {
 # "Install" iw
 function iw {
     echo "Installing iw..."
-    $install wireless-tools python-numpy python-scipy pkg-config python-matplotlib libnl-3-dev libnl-genl-3-dev libssl-dev
+    $install wireless-tools python-numpy python-scipy pkg-config python-matplotlib libnl-3-dev libnl-genl-3-dev libssl-dev patch
     pushd $MININET_DIR/mininet-wifi
     git submodule update --init --recursive
     pushd $MININET_DIR/mininet-wifi/hostap


### PR DESCRIPTION
Sometimes apt is not installing patch automatically (depends on the preinstalled packages), so I added patch to the packages to install in `util/install.sh` where it is needed.