### PR TITLE
Remove cleanup param in Mininet

### DIFF
--- a/mininet/net.py
+++ b/mininet/net.py
@@ -126,7 +126,7 @@ class Mininet(object):
                  accessPoint=OVSKernelAP, host=Host, station=Station,
                  car=Car, controller=DefaultController, isWiFi=False,
                  link=Link, intf=Intf, build=True, xterms=False,
-                 cleanup=False, ipBase='10.0.0.0/8', inNamespace=False,
+                 ipBase='10.0.0.0/8', inNamespace=False,
                  autoSetMacs=False, autoStaticArp=False, autoPinCpus=False,
                  listenPort=None, waitConnected=False, ssid="new-ssid",
                  mode="g", channel="1", enable_wmediumd=False,
@@ -170,7 +170,6 @@ class Mininet(object):
         self.repetitions = 1 # mobility: number of repetitions
         self.inNamespace = inNamespace
         self.xterms = xterms
-        self.cleanup = cleanup
         self.autoSetMacs = autoSetMacs
         self.autoSetPositions = autoSetPositions
         self.autoStaticArp = autoStaticArp
@@ -833,10 +832,6 @@ class Mininet(object):
            and up."""
         cls = Association
         cls.printCon = False
-        # Possibly we should clean up here and/or validate
-        # the topo
-        if self.cleanup:
-            pass
 
         info('*** Creating network\n')
         if not self.controllers and self.controller:


### PR DESCRIPTION
The flag is doing nothing.
Better just remove it and if the user wants to cleanup he can explicitly call for it.