### PR TITLE
Python 3 patches

### DIFF
--- a/mininet/net.py
+++ b/mininet/net.py
@@ -95,6 +95,8 @@ from time import sleep
 from itertools import chain, groupby
 from math import ceil
 
+from six import string_types
+
 from mininet.cli import CLI
 from mininet.log import info, error, debug, output, warn
 from mininet.node import (Node, Host, OVSKernelSwitch,
@@ -381,8 +383,8 @@ class Mininet(object):
             params: additional link params (optional)
             returns: link object"""
         # Accept node objects or names
-        node1 = node1 if not isinstance(node1, basestring) else self[node1]
-        node2 = node2 if not isinstance(node2, basestring) else self[node2]
+        node1 = node1 if not isinstance(node1, string_types) else self[node1]
+        node2 = node2 if not isinstance(node2, string_types) else self[node2]
         options = dict(params)
         # Port is optional
         if port1 is not None:

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -455,7 +455,7 @@ class Node( object ):
         """
         if not intf:
             return self.defaultIntf()
-        elif isinstance( intf, basestring):
+        elif isinstance( intf, string_types):
             return self.nameToIntf[ intf ]
         else:
             return intf
@@ -507,7 +507,7 @@ class Node( object ):
         """Set the default route to go through intf.
            intf: Intf or {dev <intfname> via <gw-ip> ...}"""
         # Note setParam won't call us if intf is none
-        if isinstance( intf, basestring ) and ' ' in intf:
+        if isinstance( intf, string_types ) and ' ' in intf:
             params = intf
         else:
             params = 'dev %s' % intf

--- a/mininet/util.py
+++ b/mininet/util.py
@@ -1,5 +1,6 @@
 "Utility functions for Mininet."
 
+from six import string_types
 from time import sleep
 from resource import getrlimit, setrlimit, RLIMIT_NPROC, RLIMIT_NOFILE
 from select import poll, POLLIN, POLLHUP
@@ -603,7 +604,7 @@ def waitListening(client=None, server='127.0.0.1', port=80, timeout=None):
     if not runCmd('which telnet'):
         raise Exception('Could not find telnet')
     # pylint: disable=maybe-no-member
-    serverIP = server if isinstance(server, basestring) else server.IP()
+    serverIP = server if isinstance(server, string_types) else server.IP()
     cmd = ('echo A | telnet -e A %s %s' % (serverIP, port))
     time = 0
     result = runCmd(cmd)

--- a/util/install.sh
+++ b/util/install.sh
@@ -153,7 +153,11 @@ function mn_deps {
 		    $install python-setuptools python-pexpect python-pip
 	    fi
     fi
-    pip2 install typing
+    if [ -x "$(command -v pip2)" ]; then
+        pip2 install typing
+    else
+        pip install typing
+    fi
     echo "Installing Mininet core"
     pushd $MININET_DIR/mininet-wifi
     sudo make install
@@ -170,7 +174,6 @@ function wifi_deps {
 		else
 		    $install python-scipy python-pip python-matplotlib
 	    fi
-    pip install typing
     pushd $MININET_DIR/mininet-wifi
     git submodule update --init --recursive
     pushd $MININET_DIR/mininet-wifi/hostap

--- a/util/install.sh
+++ b/util/install.sh
@@ -153,6 +153,7 @@ function mn_deps {
 		    $install python-setuptools python-pexpect python-pip
 	    fi
     fi
+    pip2 install typing
     echo "Installing Mininet core"
     pushd $MININET_DIR/mininet-wifi
     sudo make install


### PR DESCRIPTION
Fix some Python 3 incompatibilities in original Mininet code, and add a missing dependency to install script.

- Use `six.string_types` instead of `basestring`.
- Mininet depends on `typing` which is not available by default in Python2 installations, so `pip2 install` it in `install.sh`.