### PR TITLE
Remove reference to self.stations from net.py

### DIFF
--- a/mininet/net.py
+++ b/mininet/net.py
@@ -651,7 +651,7 @@ class Mininet(object):
         lost = 0
         ploss = None
         if not hosts:
-            hosts = self.hosts + self.stations
+            hosts = self.hosts
             output('*** Ping: testing ping reachability\n')
         for node in hosts:
             output('%s -> ' % node.name)


### PR DESCRIPTION
self.stations is initialised in the Mininet_Wifi class but not in the Mininet class. Thus, this line caused a crash when using vanilla Mininet (AttributeError: 'Mininet' object has no attribute 'stations').