### PR TITLE
Update lines when the APs have mobility

### DIFF
--- a/mn_wifi/plot.py
+++ b/mn_wifi/plot.py
@@ -171,6 +171,8 @@ class plot2d (object):
         cls.text(node, x, y)
         node.pltNode.set_data(x, y)
         node.pltCircle.center = x, y
+        # Enable the update of the links when the APs have mobility
+        cls.updateLine(node)
 
     @classmethod
     def pause(cls):


### PR DESCRIPTION
Enable the update of the lines (links) when the APs have mobility.

I would like it to be supported when an AP is mobile,  that his links are updated on the graph, it is a minor change, but for those of us who were doing it's necessary. We went from this to this:



![bug](https://raw.githubusercontent.com/davidcawork/testMininet-Wifi/master/doc/Topologies_img/test_movilidad_ap_bug.gif)

![no_bug](https://raw.githubusercontent.com/davidcawork/testMininet-Wifi/master/doc/Topologies_img/test_movilidad_ap.gif)