### PR TITLE
Add support for  Wifi Stations ( cmd pingallfull )

### DIFF
--- a/mn_wifi/net.py
+++ b/mn_wifi/net.py
@@ -1005,8 +1005,9 @@ class Mininet_wifi(Mininet):
         # Each value is a tuple: (src, dsd, [all ping outputs])
         all_outputs = []
         if not hosts:
-            hosts = self.hosts
+            hosts = self.hosts + self.stations
             output('*** Ping: testing ping reachability\n')
+            
         for node in hosts:
             output('%s -> ' % node.name)
             for dest in hosts:


### PR DESCRIPTION
Hello !

Reviewing the functionalities of the Mininet-Wifi CLI, I found that the pingallfull command was obsolete since it didn't include the Wi-Fi stations at the time that makes ping. I think that this small change should be added 😄 .

![cmd update](https://i.ibb.co/kmtjLmj/pullrequest-2.jpg)


