### PR TITLE
Allow running of multiple mn-wifi instances

### DIFF
--- a/mn_wifi/clean.py
+++ b/mn_wifi/clean.py
@@ -75,9 +75,23 @@ class Cleanup(object):
         cls.sh('pkill wmediumd')
         sleep(0.1)
 
-        info("\n*** Removing WiFi module and Configurations\n")
-        cls.kill_mod('mac80211_hwsim')
-        cls.kill_mod('ifb')
+        info("\n*** Removing WiFi module and Configurations\n")        
+        phy = subprocess.check_output('find /sys/kernel/debug/ieee80211 -name hwsim | cut -d/ -f 6 | sort', shell=True).decode('utf-8').split("\n")
+        phy.pop()
+        phy.sort(key=len, reverse=False)
+        count = 0
+        for phydev in phy:
+            if str(os.getpid()) in phydev:                
+                p = subprocess.Popen(["hwsim_mgmt", "-x", phydev], stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE,
+                             bufsize=-1)
+                output, err_out = p.communicate()
+            else:
+                count += 1
+        if count == 0:
+            cls.kill_mod('mac80211_hwsim')
+            cls.kill_mod('ifb')
 
         try:
             os.system('pkill -f \'wpa_supplicant -B -Dnl80211\'')

--- a/mn_wifi/module.py
+++ b/mn_wifi/module.py
@@ -33,7 +33,7 @@ class Mac80211Hwsim(object):
         return wlan_list
 
     def configPhys(self, node, **params):
-        cmd = 'find /sys/kernel/debug/ieee80211 -name hwsim | cut -d/ -f 6 | sort'
+        cmd = 'find /sys/kernel/debug/ieee80211 -name hwsim | grep %05d | cut -d/ -f 6 | sort' % os.getpid()  # grep on PID in devicelist
         phys = self.get_intf_list(cmd)  # gets virtual and phy interfaces
         wlan_list = self.get_wlan_list(phys, **params)  # gets wlan list
         self.assign_iface(node, phys, wlan_list, (len(phys)-1), **params)
@@ -51,7 +51,7 @@ class Mac80211Hwsim(object):
         cmd = 'iw dev 2>&1 | grep Interface | awk \'{print $2}\''
         Mac80211Hwsim.phyWlans = self.get_intf_list(cmd)  # gets physical wlan(s)
         self.load_module(nradios, nodes, alt_module, **params)  # loads wifi module
-        cmd = 'find /sys/kernel/debug/ieee80211 -name hwsim | cut -d/ -f 6 | sort'
+        cmd = 'find /sys/kernel/debug/ieee80211 -name hwsim | grep %05d | cut -d/ -f 6 | sort' % os.getpid()  # grep on PID in devicelist
         phys = self.get_intf_list(cmd)  # gets virtual and phy interfaces
         wlan_list = self.get_wlan_list(phys, **params)  # gets wlan list
         for node in nodes:
@@ -98,11 +98,11 @@ class Mac80211Hwsim(object):
         num = 0
         numokay = False
         self.prefix = ""
-        cmd = "find /sys/kernel/debug/ieee80211 -name hwsim | cut -d/ -f 6 | sort"
+        cmd = 'find /sys/kernel/debug/ieee80211 -name hwsim | grep %05d | cut -d/ -f 6 | sort' % os.getpid()  # grep on PID in devicelist
         phys = subprocess.check_output(cmd, shell=True).decode('utf-8').split("\n")
 
         while not numokay:
-            self.prefix = "mn%02ds" % num
+            self.prefix = "mn%05dp%02ds" % (os.getpid(), num)       # Add PID to mn-devicenames
             numokay = True
             for phy in phys:
                 if phy.startswith(self.prefix):


### PR DESCRIPTION
There is a name clash with internal mn%02ds%02d device names that prevents from running multiple instances of mn-wifi on one system, e.g. in different docker containers. Adding the current process ID to the internal names solves the problem. Additionally used kernel modules should only be unloaded when no other mn-wifi instance is running.

My use case is distance learning. If you do not like the idea, feel free to edit or reject the PR.