### PR TITLE
Add reassocation hook and thread locks

### DIFF
--- a/mn_wifi/cli.py
+++ b/mn_wifi/cli.py
@@ -2,6 +2,7 @@ import sys
 
 from mininet.cli import CLI as MN_CLI
 from mininet.log import output, error
+from threading import Lock, ThreadError
 
 
 class CLI(MN_CLI):
@@ -40,4 +41,11 @@ class CLI(MN_CLI):
         for sw in nodesL2:
             output('*** ' + sw.name + ' ' + ('-' * 72) + '\n')
             output(sw.dpctl(*args))
+
+    def waitForNode(self, node):
+        super().waitForNode(node)
+        try:
+            node.lock.release()
+        except ThreadError:
+            pass
 

--- a/mn_wifi/link.py
+++ b/mn_wifi/link.py
@@ -475,6 +475,8 @@ class IntfWireless(Intf):
                     self.wep(ap_intf)
                     associated = 1
         if associated:
+            if 'associate_callback' in self.node.params:
+                self.node.params['associate_callback'](self)
             self.update_client_params(ap_intf)
 
     def configureWirelessLink(self, ap_intf):


### PR DESCRIPTION
Adds association callback as discussed in [232](https://github.com/intrig-unicamp/mininet-wifi/issues/232). 

Thread locks added as mininet is single-threaded and this can cause concurrency issues. This problem occurs independent of the callback addition and can be reproduced in current mininet-wifi build by running a command from the CLI (such as ping) on a mobile node that tries to de-associate from an AP while the CLI command is still running.