### PR TITLE
Re-enable WEP support in hostapd.

### DIFF
--- a/util/hostap-patches/config.patch
+++ b/util/hostap-patches/config.patch
@@ -109,6 +109,15 @@ index cbdd2a5..3da654e 100644
  
  # Wired equivalent privacy (WEP)
  # WEP is an obsolete cryptographic data confidentiality algorithm that is not
+@@ -387,7 +389,7 @@ CONFIG_IPV6=y
+ # functionality needed to use WEP is available in the current hostapd
+ # release under this optional build parameter. This functionality is subject to
+ # be completely removed in a future release.
+-#CONFIG_WEP=y
++CONFIG_WEP=y
+ 
+ # Remove all TKIP functionality
+ # TKIP is an old cryptographic data confidentiality algorithm that is not
 diff --git wpa_supplicant/bgscan_learn.c wpa_supplicant/bgscan_learn.c
 index cb732f7..ebac73b 100644
 --- wpa_supplicant/bgscan_learn.c

--- a/util/install.sh
+++ b/util/install.sh
@@ -233,6 +233,8 @@ function wifi_deps {
     fi
     pushd $MININET_DIR/mininet-wifi/hostap/hostapd
     cp defconfig .config
+    # Enable WEP support
+    echo "CONFIG_WEP=y" >> .config
     sudo make && make install
     pushd $MININET_DIR/mininet-wifi/hostap/wpa_supplicant
     cp defconfig .config

--- a/util/install.sh
+++ b/util/install.sh
@@ -233,8 +233,6 @@ function wifi_deps {
     fi
     pushd $MININET_DIR/mininet-wifi/hostap/hostapd
     cp defconfig .config
-    # Enable WEP support
-    echo "CONFIG_WEP=y" >> .config
     sudo make && make install
     pushd $MININET_DIR/mininet-wifi/hostap/wpa_supplicant
     cp defconfig .config


### PR DESCRIPTION
WEP support in hostapd has been disabled (for good reasons) [1].
Nevertheless I would like to use WEP for teaching IT security in a simulated environment, so I propose to add 'CONFIG_WEP=y' to the hostapd '.config' before building it.

[1] https://www.spinics.net/lists/hostap/msg07752.html