### PR TITLE
bmv2.py: added timeout parameter for P4Switch class

### DIFF
--- a/mn_wifi/bmv2.py
+++ b/mn_wifi/bmv2.py
@@ -134,7 +134,7 @@ class P4Switch(Switch):
                  thriftport=None, netcfg=False, dryrun=False, inNamespace=False,
                  inband=False, pipeconf=DEFAULT_PIPECONF, pktdump=False, valgrind=False,
                  gnmi=False, portcfg=True, onosdevid=None, stratum=False,
-                 switch_config=None, **kwargs):
+                 switch_config=None, timeout=SWITCH_START_TIMEOUT, **kwargs):
         Switch.__init__(self, name, inNamespace=inNamespace, **kwargs)
         self.grpcPort = grpcport
         self.grpcPortInternal = None  # Needed for Stratum (local_hercules_url)
@@ -178,6 +178,7 @@ class P4Switch(Switch):
         self.targetName = STRATUM_BMV2 if self.useStratum else SIMPLE_SWITCH_GRPC
         self.controllers = None
         self.switch_config = switch_config
+        self.timeout = timeout
 
         path = os.path.dirname(os.path.abspath(__file__)) + '/examples/p4/ap-runtime.json'
         self.json = path if not json else json
@@ -497,7 +498,7 @@ nodes {{
         # Wait for switch to open gRPC port, before sending ONOS the netcfg.
         # Include time-out just in case something hangs.
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        endtime = time.time() + SWITCH_START_TIMEOUT
+        endtime = time.time() + self.timeout
 
         if self.inNamespace:
             controller = self.configNameSpace()


### PR DESCRIPTION
When we trying to load a very large json configuration file, the default timeout of 10 seconds is not enough.

For this, I extended the P4Switch class to support the customizable timeout parameter.

So, when we need a timeout greater than 10 seconds, we can use it directly as a parameter of the P4Switch class as follows:
```
s1 = net.addSwitch ('s1', cls=P4Switch, netcfg=True, loglevel='debug', json=bigfile.json, thriftport=50001, timeout=15)
```