### PR TITLE
Allow storage of tc values for IFB and preventing overwrites by mobility

### DIFF
--- a/mn_wifi/link.py
+++ b/mn_wifi/link.py
@@ -54,6 +54,9 @@ class IntfWireless(Intf):
         self.config(**params)
 
     def configWLink(self, dist=0):
+        # If these values have been configured manually, don't overwrite
+        if intf in self.node.intf_tc.keys():
+            return
         bw = self.getBW(dist)
         loss = self.getLoss(dist)
         latency = self.getLatency(dist)
@@ -1077,7 +1080,7 @@ class WirelessLink(TCIntf, IntfWireless):
                                            max_queue_size=max_queue_size,
                                            parent=parent)
         cmds += delaycmds
-
+        self.node.intf_tc[self.name] = (bw, delay, loss)
         # Execute all the commands in our node
         debug("at map stage w/cmds: %s\n" % cmds)
         tcoutputs = [self.tc(cmd) for cmd in cmds]

--- a/mn_wifi/net.py
+++ b/mn_wifi/net.py
@@ -1145,6 +1145,7 @@ class Mininet_wifi(Mininet, Mininet_IoT):
             if self.ifb:
                 node.configIFB(wlan, self.ifbIntf)  # Adding Support to IFB
                 node.wintfs[wlan].ifb = 'ifb' + str(wlan + 1)
+                node.intfs[wlan].ifb = 'ifb' + str(wlan + 1)
                 self.ifbIntf += 1
 
     def configNode(self, node):

--- a/mn_wifi/node.py
+++ b/mn_wifi/node.py
@@ -71,6 +71,9 @@ class Node_wifi(Node):
         self.wports = {}  # dict of interfaces to port numbers
         self.nameToIntf = {}  # dict of interface names to Intfs
 
+        self.intf_tc = {} #dict of TC link parameters to intfs
+        #self.loss, self.bw, self.delay = None, None, None 
+
         # Make pylint happy
         (self.shell, self.execed, self.pid, self.stdin, self.stdout,
          self.lastPid, self.lastCmd, self.pollOut) = (
@@ -114,8 +117,18 @@ class Node_wifi(Node):
     def setMasterMode(self, intf=None, **kwargs):
         self.getNameToWintf(intf).setMasterMode(**kwargs)
 
-    def setTC(self, intf=None, **kwargs):
-        self.getNameToWintf(intf).config_tc(**kwargs)
+    def setTC(self, intf=None, useOldParams=False, **kwargs):
+        wlanIntf = self.getNameToWintf(intf)
+        if useOldParams:
+            if wlanIntf.name in self.intf_tc.keys():
+                bw, delay, loss = self.intf_tc[wlanIntf.name]
+                if "latency" not in kwargs and delay:
+                    kwargs["latency"] = float(delay[:-2]) # Strip ms from val
+                if "bw" not in kwargs and bw:
+                    kwargs["bw"] = float(bw)
+                if "loss" not in kwargs and loss:
+                    kwargs["loss"] = float(loss)
+        wlanIntf.config_tc(**kwargs)
 
     def setOCBMode(self, **params):
         ITSLink(self, **params)

--- a/mn_wifi/node.py
+++ b/mn_wifi/node.py
@@ -117,18 +117,8 @@ class Node_wifi(Node):
     def setMasterMode(self, intf=None, **kwargs):
         self.getNameToWintf(intf).setMasterMode(**kwargs)
 
-    def setTC(self, intf=None, useOldParams=False, **kwargs):
-        wlanIntf = self.getNameToWintf(intf)
-        if useOldParams:
-            if wlanIntf.name in self.intf_tc.keys():
-                bw, delay, loss = self.intf_tc[wlanIntf.name]
-                if "latency" not in kwargs and delay:
-                    kwargs["latency"] = float(delay[:-2]) # Strip ms from val
-                if "bw" not in kwargs and bw:
-                    kwargs["bw"] = float(bw)
-                if "loss" not in kwargs and loss:
-                    kwargs["loss"] = float(loss)
-        wlanIntf.config_tc(**kwargs)
+    def setTC(self, intf=None, **kwargs):
+        self.getNameToWintf(intf).config_tc(**kwargs)
 
     def setOCBMode(self, **params):
         ITSLink(self, **params)

--- a/mn_wifi/node.py
+++ b/mn_wifi/node.py
@@ -114,6 +114,9 @@ class Node_wifi(Node):
     def setMasterMode(self, intf=None, **kwargs):
         self.getNameToWintf(intf).setMasterMode(**kwargs)
 
+    def setTC(self, intf=None, **kwargs):
+        self.getNameToWintf(intf).config_tc(**kwargs)
+
     def setOCBMode(self, **params):
         ITSLink(self, **params)
 


### PR DESCRIPTION
This change introduces improvements to the current handling of tc parameters for wireless interfaces. While they are presently discarded upon being set, this change stores them on a per interface basis on their parent node and allows the user to use the setTC method on nodes to configure these parameters automatically for IFBs. This also allows for the user to prevent configured tc values being overwritten by mobility code.