### PR TITLE
Fix to connectionsTo for bug with string representation

### DIFF
--- a/mn_wifi/node.py
+++ b/mn_wifi/node.py
@@ -346,7 +346,7 @@ class Node_wifi(Node):
         connections = []
         for intf in self.intfList():
             link = intf.link
-            if link and link.intf2 is not None and 'wifi' not in link.intf2:
+            if link and link.intf2 is not None and 'wifi' not in str(link.intf2):
                 node1, node2 = link.intf1.node, link.intf2.node
                 if node1 == self and node2 == node:
                     connections += [ (intf, link.intf2) ]


### PR DESCRIPTION
Mininet-WIfi locally raised issues regarding using the "in" keyword to check against the name of interfaces, which does not seem to work as it appears to be checking against the TCIntf object itself instead. This fix makes it explicitly look at the string representation and solves the error. 