### PR TITLE
Revert "Allow storage of tc values for IFB and preventing overwrites by mobility"

### DIFF
--- a/mn_wifi/link.py
+++ b/mn_wifi/link.py
@@ -54,9 +54,6 @@ class IntfWireless(Intf):
         self.config(**params)
 
     def configWLink(self, dist=0):
-        # If these values have been configured manually, don't overwrite
-        if intf in self.node.intf_tc.keys():
-            return
         bw = self.get_bw(dist)
         loss = self.get_loss(dist)
         latency = self.get_latency(dist)
@@ -1073,7 +1070,7 @@ class WirelessLink(TCIntf, IntfWireless):
                                            max_queue_size=max_queue_size,
                                            parent=parent)
         cmds += delaycmds
-        self.node.intf_tc[self.name] = (bw, delay, loss)
+
         # Execute all the commands in our node
         debug("at map stage w/cmds: {}\n".format(cmds))
         tcoutputs = [self.tc(cmd) for cmd in cmds]

--- a/mn_wifi/net.py
+++ b/mn_wifi/net.py
@@ -1146,7 +1146,6 @@ class Mininet_wifi(Mininet, Mininet_IoT):
             if self.ifb:
                 node.configIFB(wlan, self.ifbIntf)  # Adding Support to IFB
                 node.wintfs[wlan].ifb = 'ifb' + str(wlan + 1)
-                node.intfs[wlan].ifb = 'ifb' + str(wlan + 1)
                 self.ifbIntf += 1
 
     def configNode(self, node):

--- a/mn_wifi/node.py
+++ b/mn_wifi/node.py
@@ -71,8 +71,6 @@ class Node_wifi(Node):
         self.wports = {}  # dict of interfaces to port numbers
         self.nameToIntf = {}  # dict of interface names to Intfs
 
-        self.intf_tc = {} #dict of intfs to TC link parameters (tuple of bw, loss, and delay)
-
         # Make pylint happy
         (self.shell, self.execed, self.pid, self.stdin, self.stdout,
          self.lastPid, self.lastCmd, self.pollOut) = (


### PR DESCRIPTION
Reverts intrig-unicamp/mininet-wifi#396

There is an error in 
`if intf in self.node.intf_tc.keys():`

`intf` is not defined