### PR TITLE
update sumo relative path and sumo vehicle name in mininet wifi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ mnexec
 *.swp
 \#*\#
 mininet.egg-info
+mininet_wifi.egg-info
 build
 dist
 doc/html

--- a/examples/v2x/change_lane/conf/gui-settings.cfg
+++ b/examples/v2x/change_lane/conf/gui-settings.cfg
@@ -1,0 +1,3 @@
+<viewsettings>
+    <scheme name="real world"/>
+</viewsettings>

--- a/examples/v2x/change_lane/conf/map.sumocfg
+++ b/examples/v2x/change_lane/conf/map.sumocfg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.sf.net/xsd/sumoConfiguration.xsd">
+
+    <input>
+        <net-file value="net.xml"/>
+        <route-files value="rou.xml"/>
+        <gui-settings-file value="gui-settings.cfg"/>
+    </input>
+
+    <time>
+        <begin value="0"/>
+        <end value="100000"/>
+	<step-length value="0.1"/>
+    </time>
+
+    <traci_server>
+        <processing>
+            <time-to-teleport value="100"/>
+        </processing>
+        <remote-port value="8813"/>
+    </traci_server>
+</configuration>

--- a/examples/v2x/change_lane/conf/net.xml
+++ b/examples/v2x/change_lane/conf/net.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on 2021-10-05 12:15:02 by Eclipse SUMO netedit Version 1.10.0
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/netconvertConfiguration.xsd">
+
+    <output>
+        <output-file value="/Users/aoo/Desktop/uc01.net.xml"/>
+        <plain-output-prefix value=""/>
+    </output>
+
+    <processing>
+        <offset.disable-normalization value="true"/>
+    </processing>
+
+    <junctions>
+        <no-turnarounds value="true"/>
+    </junctions>
+
+    <report>
+        <aggregate-warnings value="5"/>
+    </report>
+
+</configuration>
+-->
+
+<net version="1.9" junctionCornerDetail="5" limitTurnSpeed="5.50" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/net_file.xsd">
+
+    <location netOffset="0.00,0.00" convBoundary="0.00,0.00,200.00,0.00" origBoundary="10000000000.00,10000000000.00,-10000000000.00,-10000000000.00" projParameter="!"/>
+
+    <edge id=":gneJ1_0" function="internal">
+        <lane id=":gneJ1_0_0" index="0" speed="13.89" length="0.10" shape="50.00,-4.80 50.00,-4.80"/>
+        <lane id=":gneJ1_0_1" index="1" speed="13.89" length="0.10" shape="50.00,-1.60 50.00,-1.60"/>
+    </edge>
+    <edge id=":gneJ2_0" function="internal">
+        <lane id=":gneJ2_0_0" index="0" speed="13.89" length="0.10" shape="100.00,-4.80 100.00,-4.80"/>
+        <lane id=":gneJ2_0_1" index="1" speed="13.89" length="0.10" shape="100.00,-1.60 100.00,-1.60"/>
+    </edge>
+    <edge id=":gneJ3_0" function="internal">
+        <lane id=":gneJ3_0_0" index="0" speed="13.89" length="0.10" shape="150.00,-4.80 150.00,-4.80"/>
+        <lane id=":gneJ3_0_1" index="1" speed="13.89" length="0.10" shape="150.00,-1.60 150.00,-1.60"/>
+    </edge>
+
+    <edge id="gneE0" from="gneJ0" to="gneJ1" priority="-1">
+        <lane id="gneE0_0" index="0" speed="13.89" length="50.00" shape="0.00,-4.80 50.00,-4.80"/>
+        <lane id="gneE0_1" index="1" speed="13.89" length="50.00" shape="0.00,-1.60 50.00,-1.60"/>
+    </edge>
+    <edge id="gneE1" from="gneJ1" to="gneJ2" priority="-1">
+        <lane id="gneE1_0" index="0" speed="13.89" length="50.00" shape="50.00,-4.80 100.00,-4.80"/>
+        <lane id="gneE1_1" index="1" speed="13.89" length="50.00" shape="50.00,-1.60 100.00,-1.60"/>
+    </edge>
+    <edge id="gneE2" from="gneJ2" to="gneJ3" priority="-1">
+        <lane id="gneE2_0" index="0" speed="13.89" length="50.00" shape="100.00,-4.80 150.00,-4.80"/>
+        <lane id="gneE2_1" index="1" speed="13.89" length="50.00" shape="100.00,-1.60 150.00,-1.60"/>
+    </edge>
+    <edge id="gneE3" from="gneJ3" to="gneJ4" priority="-1">
+        <lane id="gneE3_0" index="0" speed="13.89" length="50.00" shape="150.00,-4.80 200.00,-4.80"/>
+        <lane id="gneE3_1" index="1" speed="13.89" length="50.00" shape="150.00,-1.60 200.00,-1.60"/>
+    </edge>
+
+    <junction id="gneJ0" type="dead_end" x="0.00" y="0.00" incLanes="" intLanes="" shape="0.00,0.00 0.00,-6.40"/>
+    <junction id="gneJ1" type="priority" x="50.00" y="0.00" incLanes="gneE0_0 gneE0_1" intLanes=":gneJ1_0_0 :gneJ1_0_1" shape="50.00,0.00 50.00,-6.40 50.00,0.00">
+        <request index="0" response="00" foes="00" cont="0"/>
+        <request index="1" response="00" foes="00" cont="0"/>
+    </junction>
+    <junction id="gneJ2" type="priority" x="100.00" y="0.00" incLanes="gneE1_0 gneE1_1" intLanes=":gneJ2_0_0 :gneJ2_0_1" shape="100.00,0.00 100.00,-6.40 100.00,0.00">
+        <request index="0" response="00" foes="00" cont="0"/>
+        <request index="1" response="00" foes="00" cont="0"/>
+    </junction>
+    <junction id="gneJ3" type="priority" x="150.00" y="0.00" incLanes="gneE2_0 gneE2_1" intLanes=":gneJ3_0_0 :gneJ3_0_1" shape="150.00,0.00 150.00,-6.40 150.00,0.00">
+        <request index="0" response="00" foes="00" cont="0"/>
+        <request index="1" response="00" foes="00" cont="0"/>
+    </junction>
+    <junction id="gneJ4" type="dead_end" x="200.00" y="0.00" incLanes="gneE3_0 gneE3_1" intLanes="" shape="200.00,-6.40 200.00,0.00"/>
+
+    <connection from="gneE0" to="gneE1" fromLane="0" toLane="0" via=":gneJ1_0_0" dir="s" state="M"/>
+    <connection from="gneE0" to="gneE1" fromLane="1" toLane="1" via=":gneJ1_0_1" dir="s" state="M"/>
+    <connection from="gneE1" to="gneE2" fromLane="0" toLane="0" via=":gneJ2_0_0" dir="s" state="M"/>
+    <connection from="gneE1" to="gneE2" fromLane="1" toLane="1" via=":gneJ2_0_1" dir="s" state="M"/>
+    <connection from="gneE2" to="gneE3" fromLane="0" toLane="0" via=":gneJ3_0_0" dir="s" state="M"/>
+    <connection from="gneE2" to="gneE3" fromLane="1" toLane="1" via=":gneJ3_0_1" dir="s" state="M"/>
+
+    <connection from=":gneJ1_0" to="gneE1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ1_0" to="gneE1" fromLane="1" toLane="1" dir="s" state="M"/>
+    <connection from=":gneJ2_0" to="gneE2" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ2_0" to="gneE2" fromLane="1" toLane="1" dir="s" state="M"/>
+    <connection from=":gneJ3_0" to="gneE3" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ3_0" to="gneE3" fromLane="1" toLane="1" dir="s" state="M"/>
+
+</net>

--- a/examples/v2x/change_lane/conf/rou.xml
+++ b/examples/v2x/change_lane/conf/rou.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+
+    <vType id="car" guiShape="passenger/sedan" sigma="0">
+        <param key="parking.distance.weight" value="1"/> 
+    </vType>
+
+    <vType id="obs" guiShape="evehicle" sigma="0">
+        <param key="parking.distance.weight" value="1"/> 
+    </vType>
+
+    <route edges="gneE0 gneE1 gneE2 gneE3" id="route0">
+    </route>
+
+    <route edges="gneE0 gneE1 gneE2 gneE3" id="route1">
+    </route>
+
+    <route edges="gneE0 gneE1 gneE2 gneE3" id="route2"/>
+
+    <route edges="gneE2" id="stop">
+        <stop lane="gneE2_0" startPos="0" endPos="1" duration="100"/>
+    </route>
+
+    <vehicle id="obs" type="obs" arrivalLane="0" depart="0.00" route="stop" color="red"/>
+    <vehicle id="car1" type="car" depart="0.00" route="route0" departLane="1" color="yellow" />
+    <vehicle id="car2" type="car" depart="2.00" route="route1" departLane="0" color="yellow" />
+
+
+</routes>

--- a/examples/v2x/change_lane/main.py
+++ b/examples/v2x/change_lane/main.py
@@ -1,0 +1,89 @@
+from typing import List
+from mininet.log import setLogLevel, info
+from mn_wifi.cli import CLI
+from mn_wifi.net import Mininet_wifi
+from mn_wifi.node import Car
+from mn_wifi.sumo.invoker import SumoInvoker
+from mn_wifi.sumo.controller import SumoControlThread
+from mn_wifi.link import wmediumd, mesh as Mesh
+from mn_wifi.wmediumdConnector import interference
+
+from vlc import CarController
+
+import os
+
+if __name__ == '__main__':
+
+    setLogLevel('info')
+    net = Mininet_wifi(link=wmediumd, wmediumd_mode=interference)
+    "Create a network."
+    info("*** Creating nodes\n")
+
+    for name in ['obs', 'car1', 'car2', 'car3']: 
+        net.addCar(name, wlans=2, encrypt=[None, 'wpa2'])
+
+    kwargs = {
+        'ssid': 'vanet-ssid', 
+        'mode': 'g', 
+        'passwd': '123456789a',
+        'encrypt': 'wpa2', 
+        'failMode': 'standalone', 
+        'datapath': 'user'
+    }
+    net.addAccessPoint(
+        'e1', mac='00:00:00:11:00:01', channel='1',
+        position='100,25,0', range=200, **kwargs
+    )
+    info("*** Configuring Propagation Model\n")
+    net.setPropagationModel(model="logDistance", exp=4.5)
+
+    info("*** Configuring wifi nodes\n")
+    net.configureWifiNodes()
+
+    controlled_cars: List[Car] = net.cars[1:3]
+    for node in controlled_cars: 
+        net.addLink(
+            node, cls=Mesh, intf=node.intfNames()[0], 
+            ssid='meshNet', channel=5, ht_cap='HT40+'
+        )
+
+    info("*** Starting network\n")
+    net.build()
+
+    for enb in net.aps:
+        enb.start([])
+    
+    for i, mn_car in enumerate(controlled_cars, start=1): 
+        mn_car.setIP(ip=f'192.168.0.{i}', intf=mn_car.intfNames()[0])
+        mn_car.setIP(ip=f'192.168.1.{i}', intf=mn_car.intfNames()[1])
+
+    nodes = controlled_cars + net.aps
+
+    net.telemetry(
+        nodes=nodes, data_type='position',
+        min_x=-50, min_y=-75,
+        max_x=250, max_y=150
+    )
+    info("***** Telemetry Initialised\n")
+
+    example_root_path = os.path.dirname(os.path.abspath(__file__))
+    cfg_file_path = os.path.join(example_root_path, 'conf' ,'map.sumocfg')
+    net.useExternalProgram(
+        program=SumoInvoker, config_file=cfg_file_path,
+        port=8813, clients=2, exec_order=0,
+        extra_params=['--delay', '1000', '--start', 'false']
+    )
+
+    sumo_ctl = SumoControlThread('SUMO_CAR_CONTROLLER', verbose=True)
+    for car in controlled_cars: sumo_ctl.add(CarController(car))
+    sumo_ctl.setDaemon(True)
+    sumo_ctl.start()
+
+    info("***** TraCI Initialised\n")
+    CLI(net)
+
+    info("***** CLI Initialised\n")
+
+    info("*** Stopping network\n")
+    net.stop()
+    

--- a/examples/v2x/change_lane/vlc.py
+++ b/examples/v2x/change_lane/vlc.py
@@ -1,0 +1,20 @@
+from mn_wifi.node import Car
+from mn_wifi.sumo.vehicle import SumoVehicle
+from mn_wifi.sumo.controller import SumoStepListener
+
+class CarController(SumoStepListener): 
+
+    def __init__(self, mnwf_car: Car):
+        super().__init__()
+        self.__car_name = mnwf_car.name
+        self.__sumo_car = SumoVehicle(mnwf_car.name)
+        self.__cur_lane = 0        
+    
+    @SumoStepListener.Substeps(priority=1)
+    def change_cur_lane(self) -> None:
+        if self.__sumo_car.distance > 75: self.__cur_lane = 1
+        self.__sumo_car.lane = self.__cur_lane
+    
+    @property
+    def name(self) -> str:
+        return f'{self.__class__.__name__}::{self.__car_name}'

--- a/mn_wifi/sumo/controller.py
+++ b/mn_wifi/sumo/controller.py
@@ -5,7 +5,7 @@ from threading import Thread
 import traceback
 from typing import Callable, List, Optional
 
-from . import traci
+import traci
 from traci.exceptions import TraCIException
 
 

--- a/mn_wifi/sumo/controller.py
+++ b/mn_wifi/sumo/controller.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from abc import ABCMeta, abstractmethod
+from threading import Thread
+import traceback
+from typing import Callable, List, Optional
+
+from . import traci
+from traci.exceptions import TraCIException
+
+
+class SumoStepListener(traci.StepListener, metaclass=ABCMeta):
+    
+    @classmethod
+    def Substeps(cls, priority: int=0):
+        def __inner(task): 
+            def __wrapper(*args,**kwargs): 
+                return task(*args,**kwargs)
+            setattr(__wrapper, 'priority', priority)
+            return __wrapper
+        return __inner
+    
+    @property
+    @abstractmethod
+    def name(self) -> str: 
+        return 'SumoStepListener'
+
+    def __init__(self) -> None:
+        super().__init__() 
+        self.__cur_step = 0
+        self.__tasks: List[Callable] = []
+        for _, field in self.__class__.__dict__.items():
+            f_priority = getattr(field, 'priority', -1)
+            if f_priority >= 0: self.__tasks.append(field)
+        self.__tasks.sort(key=lambda t: -t.priority)
+        self.is_started = False
+        self.is_alive = False
+
+    @property
+    def cur_time(self) -> float: 
+        return traci.simulation.getTime()
+
+    @property
+    def cur_step(self) -> int: 
+        return self.__cur_step
+
+    def before_listening(self): 
+        print(f'{self.name.capitalize()} START LISTENING')
+        return None
+
+    def step(self,t) -> bool:
+        '''
+        An implementation for the abstract method, traci.StepListener.step() 
+        The parameter t is the number of steps executed. In this implementation, 
+        our program will execute `t` times _step_core method. It will always 
+        return True even when the _step_core throws an error, because the program 
+        will stop if the step method return False.
+        '''
+        if self.is_started and not self.is_alive: 
+            return True
+        if t == 0: t = 1 
+        for _ in range(t): 
+            self.__cur_step += 1
+            self._step_one()
+        return True 
+
+    def _step_one(self) -> bool:
+        '''
+        The method will be invoked exact once in each traci step
+        '''
+        try: 
+            for task in self.__tasks: task(self)
+            if not self.is_started: 
+                self.is_started = True
+                self.is_alive = True
+        except TraCIException as traci_exception:
+            if self.is_started: 
+                self.is_alive = False
+                raise traci_exception
+        return True
+    
+    def after_listening(self): 
+        print(f'{self.name.capitalize()} STOP LISTENING')
+        return None
+
+
+class SumoControlThread(Thread): 
+    
+    def __init__(self, name, port:int=8813, priority:int=1, verbose=False):
+        Thread.__init__(self,name=name)   
+        traci.init(port)
+        traci.setOrder(priority)
+        self.__is_verbose = verbose
+        self.__listeners: List[SumoStepListener] = []
+
+    def run(self) -> None: 
+        for listener in self.__listeners: listener.before_listening()
+        while traci.simulation.getMinExpectedNumber() > 0 and len(self.__listeners) > 0:
+            try: 
+                traci.simulationStep()
+            except: 
+                for listener in self.__listeners: 
+                    if listener.is_alive: continue
+                    if not listener.is_started: continue
+                    listener.after_listening()
+                    self.remove(listener)
+                if self.__is_verbose: print(traceback.format_exc())
+        for listener in self.__listeners: listener.after_listening()
+        traci.close()
+        return None
+    
+    def add(self, listener: SumoStepListener) -> Optional[int]:
+        self.__listeners.append(listener)
+        listener.id = traci.addStepListener(listener)
+        return listener.id
+    
+    def remove(self, listener: SumoStepListener) -> bool:
+        self.__listeners.remove(listener)
+        return traci.removeStepListener(listener.id)

--- a/mn_wifi/sumo/invoker.py
+++ b/mn_wifi/sumo/invoker.py
@@ -1,0 +1,47 @@
+from typing import List
+from mn_wifi.node import AP, Car
+from mn_wifi.sumo.sumolib.sumolib import checkBinary
+from mn_wifi.sumo.traci import main as traci, _vehicle
+from mn_wifi.sumo.runner import sumo
+from subprocess import Popen, PIPE
+
+
+class SumoInvoker(sumo):
+
+    def __init__(self, cars: List[Car], aps: List[AP], **kwargs) -> None:
+        for car in cars: car.pos = car.position
+        return super().__init__(cars, aps, **kwargs)
+
+    def start(self, 
+        mnwf_vlc: List[Car], 
+        cfg_path:str, cli_num: int, port_num: int, exe_order: int, 
+        ex_params: List[str]
+    ):
+        cmd_list = [
+            checkBinary('sumo-gui'), 
+            '-c', cfg_path, 
+            '--num-clients', str(cli_num), 
+            '--remote-port', str(port_num), 
+            '--time-to-teleport', '-1'
+        ]
+        Popen(cmd_list + ex_params, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        traci.init(port_num)
+        traci.setOrder(exe_order)
+
+        self.setWifiParameters()
+        sumo_vlc_ctl = _vehicle.VehicleDomain()
+        sumo_vlc_ctl._connection = traci.getConnection(label="default")
+        mnwf_vlc_dict = {vlc.name:vlc for vlc in mnwf_vlc}
+        while traci.simulation.getMinExpectedNumber() > 0:
+            traci.simulationStep()
+            for vlc_id in sumo_vlc_ctl.getIDList():
+                x, y = sumo_vlc_ctl.getPosition(vlc_id)
+                if vlc_id not in mnwf_vlc_dict: continue
+                mnwf_vlc = mnwf_vlc_dict[vlc_id]
+                mnwf_vlc.position = x, y, 0
+                mnwf_vlc.set_pos_wmediumd(mnwf_vlc.position)
+
+                if hasattr(mnwf_vlc, 'sumo') and mnwf_vlc.sumo:
+                    args = list(mnwf_vlc.sumo.sumoargs)
+                    mnwf_vlc.sumo(vlc_id, sumo_vlc_ctl, *args)
+                    del mnwf_vlc.sumo

--- a/mn_wifi/sumo/traffic_light.py
+++ b/mn_wifi/sumo/traffic_light.py
@@ -1,11 +1,6 @@
 from traci import trafficlight
 from typing import Optional, List, Tuple
 
-'''
-THE CLASS CURRENTLY DID NOT SUPPORT THE TRACIT IN MININET WIFI, 
-PLEASE UPDATE THE TRACIT IN THERE.
-'''
-
 class SumoTrafficLight(object): 
 
     def __init__(self, tfl_id: str, states: List[str]):

--- a/mn_wifi/sumo/traffic_light.py
+++ b/mn_wifi/sumo/traffic_light.py
@@ -1,0 +1,36 @@
+from traci import trafficlight
+from typing import Optional, List, Tuple
+
+'''
+THE CLASS CURRENTLY DID NOT SUPPORT THE TRACIT IN MININET WIFI, 
+PLEASE UPDATE THE TRACIT IN THERE.
+'''
+
+class SumoTrafficLight(object): 
+
+    def __init__(self, tfl_id: str, states: List[str]):
+        self.__tfl_id = tfl_id
+        self.__states = states.copy()
+        self.distance = 0
+
+    @property
+    def name(self) -> str:
+        return self.__tfl_id
+
+    @property
+    def phase(self) -> str: 
+        index = trafficlight.getPhase(self.__tfl_id)
+        return self.__states[index]
+
+    @phase.setter
+    def phase(self, val: str): 
+        state_index = self.__states.index(val)
+        return trafficlight.setPhase(self.__tfl_id, state_index)
+
+    def set_state_with_duration(self, state: str, duration: Optional[int]=None) -> bool:
+        try: state_index = self.__states.index(state)
+        except: return False
+        trafficlight.setPhaseDuration(self.__tfl_id, state_index, duration)
+    
+    def get_leader_with_distance(self) -> Tuple: 
+        return (None, None)

--- a/mn_wifi/sumo/vehicle.py
+++ b/mn_wifi/sumo/vehicle.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Tuple
 from math import sqrt
-from . import traci
+import traci
 
 class SumoVehicle(object): 
 

--- a/mn_wifi/sumo/vehicle.py
+++ b/mn_wifi/sumo/vehicle.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+from typing import Tuple
+from math import sqrt
+from . import traci
+
+class SumoVehicle(object): 
+
+    def __init__(self, sumo_v_id: str):
+        self.__vlc = traci.vehicle
+        self.__id = sumo_v_id
+        self.__duration = 0
+
+    @property
+    def safe_gap(self) -> int: 
+        return self.__vlc.getMinGap(self.__id)
+
+    @property
+    def position(self) -> Tuple: 
+        x,y = self.__vlc.getPosition(self.__id)
+        return (x, y, 0)
+    
+    @property
+    def lane(self) -> int: 
+        return self.__vlc.getLaneIndex(self.__id) 
+    
+    @lane.setter
+    def lane(self, value: int) -> None: 
+        if self.__duration == 0: self.__duration = int(traci.simulation.getTime()) + 1
+        return self.__vlc.changeLane(self.__id, value, self.__duration)
+
+    @property
+    def speed(self) -> int:
+        return self.__vlc.getSpeed(self.__id)
+    
+    @speed.setter
+    def speed(self, ex_sp)-> None: 
+        self.__vlc.setSpeed(self.__id, ex_sp)
+    
+    @property
+    def road(self) -> str:
+        return self.__vlc.getRoadID(self.__id)
+
+    @property
+    def distance(self) -> int: 
+        return self.__vlc.getDistance(self.__id) 
+
+    @property
+    def heading(self) -> float:
+        return self.__vlc.getAngle(self.__id)
+    
+    @property
+    def name(self) -> int: 
+        return self.__id
+
+    '''
+    The is a bug for the traci.vehicle.getLeader method,
+    which will return None, if we change its lane during
+    SUMO default lane changing behaviour. 
+    '''
+    def get_leader_with_distance(self) -> Tuple[str, float]: 
+        out = self.__vlc.getLeader(self.__id)
+        return out if out is not None else (None, None)
+
+    def distance_to(self, other_pos: Tuple[int, int, int]) -> int: 
+        x1, y1, z1 = self.position
+        x2, y2, z2 = other_pos
+        dis = sqrt(pow(x1-x2, 2) + pow(y1-y2, 2) + pow(z1-z2, 2))
+        return dis if x1 > x2 else -dis
+
+    


### PR DESCRIPTION
Hi, 

I create a subclass of "[sumo](https://github.com/intrig-unicamp/mininet-wifi/blob/master/mn_wifi/sumo/runner.py)". There are some updates compared with its parent class: 
* It allows us to customise the sumo map by both relative path and absolute path. In the sumo class, the path is hard-coded into the "data" directory. 
* It allow us to use a more readable vehicle ID. In previous implementation, only numerous name are acceptable. 
* PS: extra commands parameters for sumo use different format. For example, Previous: `["--delay 1000"]` => `Current: ["--delay", "1000"]`. It is because we used the `Popen` in there without `shell=True` 

We recently make certain optimisations about v2x on mininet-wifi. We will push these updates soon in there. 

Best, 
Yichao  