### PR TITLE
fixing bug in position that occurs when user set x&y coordinates only

### DIFF
--- a/mn_wifi/node.py
+++ b/mn_wifi/node.py
@@ -240,9 +240,15 @@ class Node_wifi(Node):
                 else:
                     self.lines[line].set_data([pos_[0][0], pos[0]], [pos_[1][0], pos[1]])
 
-    def getxyz(self):
-        pos = self.position
-        x, y, z = round(pos[0], 2), round(pos[1], 2), round(pos[2], 2)
+    def getxyz(self): 
+        pos = self.position 
+        x,y = round(pos[0], 2), round(pos[1], 2)
+        #only access third element if it exists 
+        if len(pos) == 3:
+            z = round(pos[2], 2) 
+        #otherwise, set z to 0 
+        else: 
+            z = 0 
         return x, y, z
 
     def update_3d(self):


### PR DESCRIPTION
in class node, there is a function called _getxyz()_
This function causes errors when the user enter only two coordinates, because it assumes the user
entered three coordinates.
So, I added simple if condition to check if the user didn't enter the three coordinates, it sets z to 0