### PR TITLE
Fix TCLinkWireless class

### DIFF
--- a/mn_wifi/link.py
+++ b/mn_wifi/link.py
@@ -1255,6 +1255,8 @@ class TCLinkWireless(WirelessIntf):
 
     def __init__(self, node, port=None, intfName=None,
                  addr=None, cls=WirelessLink, **params):
+        if cls == TCLinkWireless:
+            cls = WirelessLink
         WirelessIntf.__init__(self, node=node, port=port,
                               intfName=intfName, cls=cls,
                               addr=addr, **params)


### PR DESCRIPTION
Error in class TCLinkWireless: provided "cls" argument "TCLinkWireless" causes looping and error.

Topology creation with Mininet_wifi(topo=topo, cls=TCLinkWireless) ends with error:

`TypeError: mn_wifi.link.WirelessLink() got multiple values for keyword argument 'name'`

Creation example:
[topo-1ap-2sta.txt](https://github.com/intrig-unicamp/mininet-wifi/files/9732111/topo-1ap-2sta.txt)

Problem: during __init__ WirelessIntf does `intf1 = cls(name=intfName, node=node, link=self, mac=addr, **params)` and if it WirelessIntf was called from TCLinkWireless with cls = TCLinkWireless it causes looping

