### PR TITLE
Adds the possibility to run mininet-wifi with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Use python:3.9 as base
+FROM python:3.9
+
+# Create a work directory for mininetwifi project
+WORKDIR /app/mininet-wifi
+
+# Install dependencies for mininet wifi over debian which is the base OS for python:3.9 image
+RUN apt update 
+RUN apt install -y sudo git make help2man pyflakes3 python3-pep8 tcpdump wpan-tools
+RUN pip install six numpy matplotlib
+
+# Copy project into the image
+COPY . . 
+
+# Fix install script outdated dependencies names solved by this dockerfile.
+RUN sed -i 's/pyflakes//g' util/install.sh && sed -i 's/pep8//g' util/install.sh
+
+# Run the installation script
+RUN util/install.sh -Wlnfv 
+
+# Set the dafault init to use bash shell
+CMD [ "/bin/bash" ]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ _optional_:
 #### Docker
 **This is recommended if you are using a different linux distribution from the ones supported by the installation script.** 
 
-If you prefer to use Mininet-WiFi with Docker you should follow the steps:
+If you prefer to use Mininet-WiFi with Docker you should follow the steps described below:
 
 1. Building the docker image:
     ```sh

--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ _optional_:
 -P: P4 dependencies    
 -6: wpan tools
 
+#### Docker
+**This is recommended if you are using a different linux distribution from the ones supported by the installation script.** 
+
+If you prefer to use Mininet-WiFi with Docker you should follow the steps:
+
+1. Building the docker image:
+    ```sh
+    docker build -t mn-wifi:v1 .
+    ```
+
+2. Running the container: Mininet-WiFi relies on Kernel modules from the host, requires elevated privilege, and the host network interface:
+
+    ```sh
+    docker run -it --rm --privileged --env="DISPLAY" --env="QT_X11_NO_MITSHM=1" -v /tmp/.X11-unix:/tmp/.X11-unix:rw --net host -v /sys/:/sys -v /lib/modules:/lib/modules -v /sys/kernel/debug:/sys/kernel/debug -v /var/run/netns:/var/run/netns mn-wifi:v1
+    ```
+
 ### Building Topologies with GUI
 
 ![](https://github.com/ramonfontes/vnd/blob/master/miniedit.png)


### PR DESCRIPTION
This add a Dockerfile and a section on readme about executing mininet-wifi using docker. I created this because i wanted to run mininet-wifi on a different linux distribution than the ones supported by the install script.