### PR TITLE
Fix ofsoftswitch13 compilation

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -563,6 +563,7 @@ function of13 {
     # Resume the install:
     cd $BUILD_DIR/ofsoftswitch13
     ./boot.sh
+    sed -i 's/^AM_CFLAGS = -Wstrict-prototypes -Werror$/AM_CFLAGS = -Wstrict-prototypes -Werror -Wno-error=stringop-truncation -Wno-error=format-truncation=/g' Makefile.am
     ./configure
     make
     sudo make install


### PR DESCRIPTION
Hi there,

I'm leaving this here, in case someone might find it useful.. After searching for information related to this bug, I found that there is already a person who has offered a solution (@cheriimoya), disabling the errors when there are warnings in the ofsoftswitch13 build. 

I leave here the references to the PRs to [Mininet](https://github.com/mininet/mininet/pull/1104) and [ofsoftswitch13](https://github.com/CPqD/ofsoftswitch13/pull/313). 

With this modification I already have Mininet-wifi working on Ubuntu 22.04 with the ofsoftswitch13 working (`UserAP`).

Best,