### PR TITLE
Update install.sh

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -187,7 +187,7 @@ function wifi_deps {
     else
         pf=pyflakes
         if [ $PYTHON_VERSION == 3 ]; then
-            $install python-is-python3
+            ln -sf python3 /usr/bin/python
         fi
         # Starting around 20.04, installing pyflakes instead of pyflakes3
         # causes Python 2 to be installed, which is exactly NOT what we want.


### PR DESCRIPTION
The python-is-python3 is not available in older versions of ubuntu (like bionic). This PR replaces that package with a call to `ln` which is equivalent.