### PR TITLE
Modify test expression to fix a logical short circuit

### DIFF
--- a/mn_wifi/link.py
+++ b/mn_wifi/link.py
@@ -433,7 +433,7 @@ class IntfWireless(Intf):
 
             if self.config:
                 config = self.config
-                if config is not []:
+                if config != []:
                     config = self.config.split(',')
                     self.node.params.pop("config", None)
                     for conf in config:
@@ -820,7 +820,7 @@ class HostapdConfig(IntfWireless):
         if intf.client_isolation: cmd += '\nap_isolate=1'
         if 'config' in intf.node.params:
             config = intf.node.params['config']
-            if config is not []:
+            if config != []:
                 config = config.split(',')
                 # ap.params.pop("config", None)
                 for conf in config: cmd += "\n" + conf


### PR DESCRIPTION
In file: link.py, in two methods, there are two logical expressions that use the identity operator. A new object is created inside the identity check operation and then used for matching identity. Since this is a distinct, new object, it will not have identity an match with anything else. As a result, the identity check will have a logical short circuit and the program may have unintended behavior. 

In this case, the following binary operation

      `config is not []`

compares a newly created object with the identity operator which will always evaluate to True.


I updated the logical operations. These should be reviewed for correctness. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.