### PR TITLE
fixed a bug by only acessing the z-axis of position if it exists

### DIFF
--- a/mn_wifi/mobility.py
+++ b/mn_wifi/mobility.py
@@ -36,7 +36,7 @@ class Mobility(object):
         node.position = init_pos
         pos_x = float(fin_pos[0]) - float(init_pos[0])
         pos_y = float(fin_pos[1]) - float(init_pos[1])
-        pos_z = float(fin_pos[2]) - float(init_pos[2])
+        pos_z = float(fin_pos[2]) - float(init_pos[2]) if len(fin_pos) == 3 else float(0)
 
         pos = round(pos_x/diff_time*0.1, 2),\
               round(pos_y/diff_time*0.1, 2),\
@@ -45,7 +45,10 @@ class Mobility(object):
 
     @staticmethod
     def get_position(pos):
-        return float('%s' % pos[0]), float('%s' % pos[1]), float('%s' % pos[2])
+        x = float('%s' % pos[0])
+        y = float('%s' % pos[1])
+        z = float('%s' % pos[2]) if len(pos) == 3 else float('%s' % 0)
+        return x, y, z
 
     @staticmethod
     def speed(node, pos_x, pos_y, pos_z, mob_time):

--- a/mn_wifi/vanet.py
+++ b/mn_wifi/vanet.py
@@ -157,7 +157,7 @@ class vanet(Mobility):
 
     def display_cars(self, cars):
         car_lines = []
-
+        
         for _ in range(len(cars)):
             n = randint(0, len(self.roads)-1)
             car_lines.append(self.roads[n])
@@ -237,12 +237,11 @@ class vanet(Mobility):
         return ang
 
     def carProp(self, point, ang, x_min, x_max, y_min, y_max):
-        temp = [point[0], point[1], ang, x_min, x_max, y_min, y_max]
-        return temp
+
+        return [point[0], point[1], ang, x_min, x_max, y_min, y_max]
 
     def carPoint(self, point):
-        temp = [point[0], point[1]]
-        return temp
+        return [point[0], point[1]]
 
     def line_prop(self, line, car):
         line_data = line.get_data()  # Get the x and y values of the points in the line


### PR DESCRIPTION
in mobility class this function is accessing the z-axis without checking if it exists.
```
def get_position(pos):
        return float('%s' % pos[0]), float('%s' % pos[1]), float('%s' % pos[2])
```
I fixed this issue by checking if it exists before accessing it. Otherwise it's set to zero
```
def get_position(pos):
        x = float('%s' % pos[0])
        y = float('%s' % pos[1])
        z = float('%s' % pos[2]) if len(pos) == 3 else float('%s' % 0)
        return x, y, z
```
Also did the same for `move_factor`