### PR TITLE
Add simple hook for checking mobility status

### DIFF
--- a/mn_wifi/mobility.py
+++ b/mn_wifi/mobility.py
@@ -201,6 +201,11 @@ class Mobility(object):
                     self.set_handover(intf, aps)
         sleep(0.0001)
 
+    def set_mob_started(self):
+        self.mobStarted = True
+
+    def get_mob_started(self):
+        return self.mobStarted
 
 class ConfigMobility(Mobility):
 
@@ -246,6 +251,7 @@ class ConfigMobLinks(Mobility):
 class model(Mobility):
 
     def __init__(self, **kwargs):
+        self.mobStarted = False
         self.start_thread(**kwargs)
 
     def start_thread(self, **kwargs):
@@ -354,7 +360,7 @@ class model(Mobility):
         current_time = time()
         while (time() - current_time) < kwargs['mob_start_time']:
             pass
-
+        self.set_mob_started()
         self.start_mob_mod(mob, mob_nodes, draw)
 
     def start_mob_mod(self, mob, nodes, draw):
@@ -380,6 +386,7 @@ class Tracked(Mobility):
     "Used when the position of each node is previously defined"
 
     def __init__(self, **kwargs):
+        self.mobStarted = False
         self.start_thread(**kwargs)
 
     def start_thread(self, **kwargs):
@@ -440,6 +447,7 @@ class Tracked(Mobility):
                     node.params['initPos'] = fin_pos
 
             while mob_start_time <= time() - t1 <= mob_stop_time:
+                self.set_mob_started()
                 t2 = time()
                 if t2 - t1 >= i:
                     for node, pos in coordinate.items():

--- a/mn_wifi/net.py
+++ b/mn_wifi/net.py
@@ -144,6 +144,7 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
         self.iot_module = iot_module
         self.wwan_module = wwan_module
         self.ifbIntf = 0
+        self.mob_object = None
         self.mob_start_time = 0
         self.mob_stop_time = 0
         self.mob_rep = 1
@@ -736,8 +737,9 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
             stat_nodes, mob_nodes = self.get_mob_stat_nodes()
             method = TrackedMob
             if self.mob_model or self.cars or self.roads:
-                method = self.start_mobility
-            method(stat_nodes=stat_nodes, mob_nodes=mob_nodes, **mob_params)
+                method = self.start_mobility(stat_nodes=stat_nodes, mob_nodes=mob_nodes, **mob_params)
+            else:
+                self.mob_object = method(stat_nodes=stat_nodes, mob_nodes=mob_nodes, **mob_params)
             self.mob_check = True
         else:
             if self.draw and not self.isReplaying:
@@ -1237,9 +1239,9 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
         for node in kwargs.get('mob_nodes'):
             node.position, node.pos = (0, 0, 0), (0, 0, 0)
         if self.roads:
-            vanet(**kwargs)
+            self.mob_object = vanet(**kwargs)
         else:
-            MobModel(**kwargs)
+            self.mob_object = MobModel(**kwargs)
 
     def setMobilityModel(self, **kwargs):
         for key in kwargs:
@@ -1299,7 +1301,9 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
             if not hasattr(car, 'position'):
                 car.position = (0, 0, 0)
             car.pos = car.position
-        program(self.cars, self.aps, **kwargs)
+        # If other external programs are added, this will likely need
+        # to be tweaked.
+        self.mob_object = program(self.cars, self.aps, **kwargs)
 
     def start_wmediumd(self):
         wmediumd(wlinks=self.wlinks, fading_cof=self.fading_cof,
@@ -1503,6 +1507,13 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
     def start_simulation():
         "Start the simulation"
         mob.pause_simulation = False
+
+    def is_mob_started(self):
+        "Check if mobility has started"
+        if self.mob_object:
+            return self.mob_object.get_mob_started()
+        else:
+            info("is_mob_started() is not applicable or not implemented with current mobility!")
 
     @staticmethod
     def setChannelEquation(**params):

--- a/mn_wifi/sumo/runner.py
+++ b/mn_wifi/sumo/runner.py
@@ -13,6 +13,7 @@ class sumo(Mobility):
     vehCmds = None
 
     def __init__(self, cars, aps, **kwargs):
+        self.mobStarted = False
         Mobility.thread_ = thread(name='vanet', target=self.configureApp,
                                   args=(cars, aps), kwargs=dict(kwargs,))
         Mobility.thread_.daemon = True
@@ -62,7 +63,7 @@ class sumo(Mobility):
 
         vehCmds = _vehicle.VehicleDomain()
         vehCmds._connection = traci.getConnection(label="default")
-
+        self.set_mob_started()
         while True:
             traci.simulationStep()
             for vehID1 in vehCmds.getIDList():

--- a/mn_wifi/vanet.py
+++ b/mn_wifi/vanet.py
@@ -44,6 +44,7 @@ class vanet(Mobility):
 
     def __init__(self, **kwargs):
         kwargs['nodes'] = kwargs['cars']
+        self.mobStarted = False
         Mobility.thread_ = thread(name='vanet', target=self.start,
                                   kwargs=kwargs)
         Mobility.thread_.daemon = True
@@ -64,6 +65,7 @@ class vanet(Mobility):
         self.display_grid(**kwargs)
         self.display_cars(cars)
         self.set_wifi_params()
+        self.set_mob_started()
         while self.thread_._keep_alive:
             [self.scatter, self.com_lines] = \
                 self.simulate_car_movement(cars, aps, self.scatter,


### PR DESCRIPTION
Currently, there's no simple way to check whether or not mobility has started. This is problematic when there is a desire to synchronize mobility and process start-up after any sort of setup that isn't fixed in length, which makes certain kinds of apples-to-apples comparison difficult. This provides a simple method which can be used to busy wait until mobility has actually begun to most applicable mobility methods; I avoided the replay code as I'm unsure if this is applicable there.

I apologize about the messy implementation, I'm not sure if it's guaranteed that there is only one Mobility class per network so I needed to rely on instance variables. I have tested this with everything modified except the vanet class as there's no example which uses it.