### PR TITLE
Add option to bind mobility model ticks to system clock

### DIFF
--- a/mn_wifi/mobility.py
+++ b/mn_wifi/mobility.py
@@ -381,6 +381,41 @@ class model(Mobility):
             while self.pause_simulation:
                 pass
 
+class RTCModel(model):
+    def __init__(self, **kwargs):
+        self.tick_time = kwargs.get('rtc_model_mob_tick', 1)
+        super().__init__(**kwargs)
+
+    def start_mob_mod(self, mob, nodes, draw):
+        """
+        :param mob: mobility params
+        :param nodes: list of nodes
+        """
+        next_tick_time = time() + self.tick_time
+        for xy in mob:
+            for idx, node in enumerate(nodes):
+                pos = round(xy[idx][0], 2), round(xy[idx][1], 2), 0.0
+                self.set_pos(node, pos)
+                if draw:
+                    node.update_2d()
+            if draw:
+                PlotGraph.pause()
+            if self.pause_simulation:
+                while self.pause_simulation:
+                    pass
+                # When resuming simulation, reset the tick timing
+                next_tick_time = time() + self.tick_time
+                continue
+            # We try to use "best effort" scheduling- we want to have
+            # done as many ticks as there are elapsed seconds since we last
+            # performed a mobility tick and try to iterate the loop as consistently
+            # as possible
+            else:
+                while time() < next_tick_time:
+                    # If time() has been exceeded since the while loop check, don't sleep
+                    sleep(max(next_tick_time - time(), 0))
+            next_tick_time = next_tick_time + self.tick_time
+
 
 class Tracked(Mobility):
     "Used when the position of each node is previously defined"

--- a/mn_wifi/mobility.py
+++ b/mn_wifi/mobility.py
@@ -381,9 +381,9 @@ class model(Mobility):
             while self.pause_simulation:
                 pass
 
-class RTCModel(model):
+class TimedModel(model):
     def __init__(self, **kwargs):
-        self.tick_time = kwargs.get('rtc_model_mob_tick', 1)
+        self.tick_time = kwargs.get('timed_model_mob_tick', 1)
         super().__init__(**kwargs)
 
     def start_mob_mod(self, mob, nodes, draw):

--- a/mn_wifi/net.py
+++ b/mn_wifi/net.py
@@ -29,7 +29,7 @@ from mn_wifi.link import IntfWireless, wmediumd, _4address, HostapdConfig, \
     master, managed, physicalMesh, PhysicalWifiDirectLink, _4addrClient, \
     _4addrAP, phyAP
 from mn_wifi.mobility import Tracked as TrackedMob, model as MobModel, \
-    Mobility as mob, ConfigMobility, ConfigMobLinks
+    Mobility as mob, ConfigMobility, ConfigMobLinks, RTCModel
 from mn_wifi.module import Mac80211Hwsim
 from mn_wifi.node import AP, Station, Car, OVSKernelAP, physicalAP
 from mn_wifi.plot import Plot2D, Plot3D, PlotGraph
@@ -145,6 +145,8 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
         self.wwan_module = wwan_module
         self.ifbIntf = 0
         self.mob_object = None
+        self.use_rtc_model_mob = False
+        self.rtc_model_mob_tick = 1.0
         self.mob_start_time = 0
         self.mob_stop_time = 0
         self.mob_rep = 1
@@ -1231,7 +1233,10 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
         if self.roads:
             self.mob_object = vanet(**kwargs)
         else:
-            self.mob_object = MobModel(**kwargs)
+            if kwargs.get('use_rtc_model_mob'):
+                self.mob_object = RTCModel(**kwargs)
+            else:
+                self.mob_object = MobModel(**kwargs)
 
     def setMobilityModel(self, **kwargs):
         for key in kwargs:
@@ -1267,12 +1272,12 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
                       'max_x', 'max_y', 'max_z',
                       'min_v', 'max_v', 'min_wt', 'max_wt',
                       'velocity_mean', 'alpha', 'variance', 'aggregation',
-                      'g_velocity']
+                      'g_velocity', 'rtc_model_mob_tick']
         args = ['stations', 'cars', 'aps', 'draw', 'seed',
                 'roads', 'mob_start_time', 'mob_stop_time',
                 'links', 'mob_model', 'mob_rep', 'reverse',
                 'ac_method', 'pointlist', 'n_groups', 'aggregation_epoch', 'epoch',
-                'velocity']
+                'velocity', 'use_rtc_model_mob']
         args += float_args
         for arg in args:
             if arg in float_args:

--- a/mn_wifi/net.py
+++ b/mn_wifi/net.py
@@ -29,7 +29,7 @@ from mn_wifi.link import IntfWireless, wmediumd, _4address, HostapdConfig, \
     master, managed, physicalMesh, PhysicalWifiDirectLink, _4addrClient, \
     _4addrAP, phyAP
 from mn_wifi.mobility import Tracked as TrackedMob, model as MobModel, \
-    Mobility as mob, ConfigMobility, ConfigMobLinks, RTCModel
+    Mobility as mob, ConfigMobility, ConfigMobLinks, TimedModel
 from mn_wifi.module import Mac80211Hwsim
 from mn_wifi.node import AP, Station, Car, OVSKernelAP, physicalAP
 from mn_wifi.plot import Plot2D, Plot3D, PlotGraph
@@ -145,8 +145,8 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
         self.wwan_module = wwan_module
         self.ifbIntf = 0
         self.mob_object = None
-        self.use_rtc_model_mob = False
-        self.rtc_model_mob_tick = 1.0
+        self.use_timed_model_mob = False
+        self.timed_model_mob_tick = 1.0
         self.mob_start_time = 0
         self.mob_stop_time = 0
         self.mob_rep = 1
@@ -1233,8 +1233,8 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
         if self.roads:
             self.mob_object = vanet(**kwargs)
         else:
-            if kwargs.get('use_rtc_model_mob'):
-                self.mob_object = RTCModel(**kwargs)
+            if kwargs.get('use_timed_model_mob'):
+                self.mob_object = TimedModel(**kwargs)
             else:
                 self.mob_object = MobModel(**kwargs)
 
@@ -1272,12 +1272,12 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
                       'max_x', 'max_y', 'max_z',
                       'min_v', 'max_v', 'min_wt', 'max_wt',
                       'velocity_mean', 'alpha', 'variance', 'aggregation',
-                      'g_velocity', 'rtc_model_mob_tick']
+                      'g_velocity', 'timed_model_mob_tick']
         args = ['stations', 'cars', 'aps', 'draw', 'seed',
                 'roads', 'mob_start_time', 'mob_stop_time',
                 'links', 'mob_model', 'mob_rep', 'reverse',
                 'ac_method', 'pointlist', 'n_groups', 'aggregation_epoch', 'epoch',
-                'velocity', 'use_rtc_model_mob']
+                'velocity', 'use_timed_model_mob']
         args += float_args
         for arg in args:
             if arg in float_args:


### PR DESCRIPTION
Adds parameters 'use_timed_model_mob' and 'timed_model_mob_tick' to mobility model code. When enabled, these will cause mobility ticks to only occur every 'timed_model_mob_tick' seconds as long as the expected number of ticks for this time interval has occurred.

The current behavior does provide a 0.5s sleep time without the plot but does not prevent error from accumulating over time- over 30s, we can see a 100ms divergence from the expected timing of a tick develop when this sleep time is included. This likely varies from system to system, but this in turn means that reproducibility between systems is fraught. This also allows the end user to control this sleep interval and visualize the behavior as it occurs without the plot more easily.