### PR TITLE
Reset certain class variables in net.stop to allow running back-to-back Mininet-wifi instances

### DIFF
--- a/mn_wifi/net.py
+++ b/mn_wifi/net.py
@@ -881,6 +881,16 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
             info(node.name + ' ')
             node.terminate()
         info('\n')
+        info('*** Clearing variables\n')
+        Mac80211Hwsim.prefix = ""
+        Mac80211Hwsim.hwsim_ids = []
+        Mac80211Hwsim.externally_managed = False
+        Mac80211Hwsim.devices_created_dynamically = False
+        Mac80211Hwsim.phyWlans = None
+        mob.aps = []
+        mob.stations = []
+        mob.mobileNodes = []
+        info('\n')
         self.closeMininetWiFi()
         info('\n*** Done\n')
 


### PR DESCRIPTION
The code currently makes use of a number of class variables for storing per-run information, which causes crashes when trying to run multiple instances of Mininet-Wifi in the same Python3 process. Given that there are not any obvious technical limitations that would otherwise deter this, I have added initial cleanup of variables which appear to trigger crashes to ndn.stop() in some basic tests.

However, this likely deserves a full refactoring, as there are a number of additional variables which may or may not expose additional issues and moreover may not need to be at this scope.