### PR TITLE
Enable hostapd interworking

### DIFF
--- a/util/hostap-patches/config.patch
+++ b/util/hostap-patches/config.patch
@@ -74,8 +74,8 @@ index a9eab4d..fdc4dab 100644
  # Send debug messages to syslog instead of stdout
  #CONFIG_DEBUG_SYSLOG=y
 @@ -317,13 +318,13 @@ CONFIG_IPV6=y
- -#CONFIG_INTERWORKING=y
- +CONFIG_INTERWORKING=y
+-#CONFIG_INTERWORKING=y
++CONFIG_INTERWORKING=y
  
  # Hotspot 2.0
 -#CONFIG_HS20=y

--- a/util/hostap-patches/config.patch
+++ b/util/hostap-patches/config.patch
@@ -74,7 +74,8 @@ index a9eab4d..fdc4dab 100644
  # Send debug messages to syslog instead of stdout
  #CONFIG_DEBUG_SYSLOG=y
 @@ -317,13 +318,13 @@ CONFIG_IPV6=y
- #CONFIG_INTERWORKING=y
+ -#CONFIG_INTERWORKING=y
+ +CONFIG_INTERWORKING=y
  
  # Hotspot 2.0
 -#CONFIG_HS20=y


### PR DESCRIPTION
Interworking (IEEE 802.11u) / CONFIG_INTERWORKING=y
This can be used to enable functionality to improve interworking with
external networks.