### PR TITLE
change logic for wpa conf based on conf parameter from addStation

### DIFF
--- a/mn_wifi/link.py
+++ b/mn_wifi/link.py
@@ -429,16 +429,18 @@ class IntfWireless(Intf):
         else:
             if 'wpasup_globals' in self.node.params:
                 cmd += self.node.params['wpasup_globals'] + '\n'
-            cmd += 'network={\n'
 
-            if self.config:
+            if self.config or self.config == "":
                 config = self.config
-                if config != []:
+                if config != [] and self.config != "":
+                    cmd += 'network={\n'
                     config = self.config.split(',')
                     self.node.params.pop("config", None)
                     for conf in config:
                         cmd += "   " + conf + "\n"
+                    cmd += '}'
             else:
+                cmd += 'network={\n'
                 cmd += '   ssid=\"{}\"\n'.format(ap_intf.ssid)
                 if not ap_intf.authmode:
                     if passwd:
@@ -470,7 +472,7 @@ class IntfWireless(Intf):
                     cmd += '   identity=\"{}\"\n'.format(self.radius_identity)
                     cmd += '   password=\"{}\"\n'.format(self.radius_passwd)
                     cmd += '   phase2=\"autheap=MSCHAPV2\"\n'
-            cmd += '}'
+                cmd += '}'
 
         pattern = '{}_{}.staconf'.format(self.name, self.id)
         self.cmd('echo \'{}\' > {}'.format(cmd, pattern))


### PR DESCRIPTION
By default the logic includes (or expects) some values (ssid, ieee80211w, key_mgmt) to construct the wpa_supplicant.conf with the network={} parameter.

This change considers if the config attribute from addStation is set to "" (line 433 and 435), to do not include network={}.  
If config is set, it keeps working as before (lines 436-441). 
If config is not set, it keeps working as before (else statement, line 442).

This is the case when working with DPP or other more customized usage (or corner cases) that the user can choose to do not include the network={} part in the wpa_supplicant.conf.