### PR TITLE
Added default initialization for static field thread_ in EnergyMonitor

### DIFF
--- a/mn_wifi/energy.py
+++ b/mn_wifi/energy.py
@@ -106,6 +106,7 @@ class PlotEnergy:
 
 
 class EnergyMonitor:
+    thread_ = None
 
     def plotEnergy(self, **kwargs):
         EnergyMonitor.thread_ = thread(target=self.run_plot, kwargs=kwargs)


### PR DESCRIPTION
Added default initialization for static field thread_ in EnergyMonitor class to fix 'EnergyMonitor' has no attribute 'thread_' on network stop.