### PR TITLE
Added clean button to autoclean using sudo mn -c

### DIFF
--- a/examples/miniedit.py
+++ b/examples/miniedit.py
@@ -2294,7 +2294,7 @@ class MiniEdit(Frame):
         Label( toolbar, text='' ).pack()
 
         # Commands
-        for cmd, color in [ ( 'Stop', 'darkRed' ), ( 'Run', 'darkGreen' ) ]:
+        for cmd, color in [('Clean','darkblue'), ( 'Stop', 'darkRed' ), ( 'Run', 'darkGreen' ) ]:
             doCmd = getattr( self, 'do' + cmd )
             b = Button( toolbar, text=cmd, font=self.smallFont,
                         fg=color, command=doCmd )
@@ -2314,6 +2314,17 @@ class MiniEdit(Frame):
         self.stop()
         for tool in self.tools:
             self.buttons[ tool ].config( state='normal' )
+        os.system("sudo mn -c")
+    import os
+
+    def doClean(self):
+        "Clean up Mininet environment."
+        # Execute the cleanup command for Mininet
+        os.system("sudo mn -c")
+        print("Mininet environment cleaned.")
+    
+        # Show confirmation message
+        messagebox.showinfo("Cleanup", "Mininet environment cleaned.")
 
     def addNode( self, node, nodeNum, x, y, name=None):
         "Add a new node to our canvas."


### PR DESCRIPTION
Add "Clean" Button to MiniEdit Toolbar for Mininet Cleanup.

This pull request adds a "Clean" button to the MiniEdit toolbar, enabling users to quickly clean up the Mininet environment (sudo mn -c) directly from the GUI.

Features Added
    1. New "Clean" button in the toolbar with dark blue text.
    2. Calls sudo mn -c to remove leftover Mininet processes, interfaces, and namespaces.
    3. Displays a confirmation message via a messagebox after cleanup.
    4. Also integrates sudo mn -c into the existing "Stop" command for safer teardown.

Implementation Details
    1. Introduced a new doClean() method for handling the "Clean" button.
    2. Modified the doStop() method to include Mininet cleanup.
    3. Appended the "Clean" button to the existing toolbar command buttons.

Why This Is Useful
    1. Helps users avoid terminal commands for cleanup.
    2. Ensures consistent environment resets when switching topologies.
    3. Prevents errors caused by stale Mininet components.
  
![screen](https://github.com/user-attachments/assets/90e3cef0-7935-4f65-962b-fba87e334fb9)
