### PR TITLE
Add logging to yield actual effective range from range parameter

### DIFF
--- a/mn_wifi/link.py
+++ b/mn_wifi/link.py
@@ -308,8 +308,8 @@ class IntfWireless(Intf):
                      'for more information\n')
         else:
             info('*** {}: signal range of {}m requires tx power equals '
-                 'to {}dBm.\n'.format(self.name, self.range, (int(txpower) + 1)))
-            info(f'*** {self.name} Effective Range: {SetSignalRange(self).range} m\n')
+                 'to {}dBm. Effective range is equal to {} meters\n'
+                 .format(self.name, self.range, (int(txpower) + 1), SetSignalRange(self).range))
 
     def setDefaultRange(self):
         if not self.static_range:

--- a/mn_wifi/link.py
+++ b/mn_wifi/link.py
@@ -309,6 +309,7 @@ class IntfWireless(Intf):
         else:
             info('*** {}: signal range of {}m requires tx power equals '
                  'to {}dBm.\n'.format(self.name, self.range, (int(txpower) + 1)))
+            info(f'*** {self.name} Effective Range: {SetSignalRange(self).range} m\n')
 
     def setDefaultRange(self):
         if not self.static_range:


### PR DESCRIPTION
Due to intermediate math steps, the specified range parameter is often different from that provided to the underlying applications when using a propagation model- this can differ by 4-5 meters (see yielded value for 90m). This should be properly conveyed to end users, as this can impact metrics.