### PR TITLE
fetch beautifulsoup4 with pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app/mininet-wifi
 # Install dependencies for mininet wifi over debian which is the base OS for python:3.9 image
 RUN apt update 
 RUN apt install -y sudo git make help2man pyflakes3 python3-pycodestyle tcpdump wpan-tools inetutils-ping
-RUN pip install six numpy matplotlib
+RUN pip install six numpy matplotlib beautifulsoup4
 
 # Copy project into the image
 COPY . . 


### PR DESCRIPTION
Currently, the Dockerfile fails to build due to a missing module: bs4.
This PR includes a one line fix to make pip fetch bs4 (beautifulsoup4) prior to running the install script. 