### PR TITLE
Add option to PMSR/FTM-capable radio creation

### DIFF
--- a/mn_wifi/hwsim_pmsr.py
+++ b/mn_wifi/hwsim_pmsr.py
@@ -1,0 +1,115 @@
+"""Create PMSR/FTM-capable mac80211_hwsim radios via generic netlink.
+
+Self-contained (Python standard library only). mac80211_hwsim advertises IEEE
+802.11 peer measurement (FTM) only on radios whose ``HWSIM_CMD_NEW_RADIO``
+carried an ``HWSIM_ATTR_PMSR_SUPPORT`` capability. ``hwsim_mgmt`` does not send
+one, so this module issues ``NEW_RADIO`` with a default FTM capability itself,
+using the stock in-tree module -- no kernel patch, no external tool.
+"""
+import socket
+import struct
+
+NETLINK_GENERIC = 16
+GENL_ID_CTRL = 16
+CTRL_CMD_GETFAMILY = 3
+CTRL_ATTR_FAMILY_ID = 1
+CTRL_ATTR_FAMILY_NAME = 2
+
+HWSIM_CMD_NEW_RADIO = 4
+HWSIM_ATTR_RADIO_NAME = 17
+HWSIM_ATTR_PMSR_SUPPORT = 26
+
+# nl80211 peer-measurement capability attributes
+PMSR_ATTR_MAX_PEERS = 1
+PMSR_ATTR_TYPE_CAPA = 4
+PMSR_TYPE_FTM = 1
+FTM_CAPA_PREAMBLES = 5
+FTM_CAPA_BANDWIDTHS = 6
+FTM_CAPA_ASAP = 1
+FTM_CAPA_NON_ASAP = 2
+
+NLA_F_NESTED = 0x8000
+NLM_F_REQUEST = 0x01
+NLM_F_ACK = 0x04
+NLMSG_ERROR = 2
+
+# HT|VHT|HE preambles (bits 1,2,4); 20|40|80 MHz bandwidths (bits 1,2,3)
+_PREAMBLES = (1 << 1) | (1 << 2) | (1 << 4)
+_BANDWIDTHS = (1 << 1) | (1 << 2) | (1 << 3)
+
+
+def _nla(atype, payload):
+    """One netlink attribute (TLV), padded to a 4-byte boundary."""
+    pad = (4 - len(payload) % 4) % 4
+    return struct.pack('HH', len(payload) + 4, atype) + payload + b'\x00' * pad
+
+
+def _u32(atype, value):
+    return _nla(atype, struct.pack('I', value))
+
+
+def _flag(atype):
+    return _nla(atype, b'')
+
+
+def _nest(atype, *attrs):
+    return _nla(atype | NLA_F_NESTED, b''.join(attrs))
+
+
+def _pmsr_support():
+    """HWSIM_ATTR_PMSR_SUPPORT -> TYPE_CAPA -> FTM: a default FTM capability."""
+    ftm = _nest(PMSR_TYPE_FTM,
+                _u32(FTM_CAPA_PREAMBLES, _PREAMBLES),
+                _u32(FTM_CAPA_BANDWIDTHS, _BANDWIDTHS),
+                _flag(FTM_CAPA_ASAP),
+                _flag(FTM_CAPA_NON_ASAP))
+    return _nest(HWSIM_ATTR_PMSR_SUPPORT,
+                 _u32(PMSR_ATTR_MAX_PEERS, 16),
+                 _nest(PMSR_ATTR_TYPE_CAPA, ftm))
+
+
+def _request(sock, family_id, cmd, payload, seq, ack):
+    flags = NLM_F_REQUEST | (NLM_F_ACK if ack else 0)
+    genl = struct.pack('BBH', cmd, 1, 0) + payload
+    msg = struct.pack('IHHII', 16 + len(genl), family_id, flags, seq, 0) + genl
+    sock.send(msg)
+    return sock.recv(8192)
+
+
+def _resolve_family(sock, name):
+    reply = _request(sock, GENL_ID_CTRL, CTRL_CMD_GETFAMILY,
+                     _nla(CTRL_ATTR_FAMILY_NAME, name.encode() + b'\x00'),
+                     seq=1, ack=False)
+    attrs, off = reply[20:], 0          # skip nlmsghdr(16) + genlmsghdr(4)
+    while off + 4 <= len(attrs):
+        alen, atype = struct.unpack_from('HH', attrs, off)
+        if atype == CTRL_ATTR_FAMILY_ID:
+            return struct.unpack_from('H', attrs, off + 4)[0]
+        off += (alen + 3) & ~3
+    raise OSError('generic netlink family %r not found' % name)
+
+
+def create_ftm_radio(name):
+    """Create an FTM/PMSR-capable hwsim radio named ``name`` (stock module)."""
+    sock = socket.socket(socket.AF_NETLINK, socket.SOCK_RAW, NETLINK_GENERIC)
+    try:
+        sock.settimeout(5)
+        sock.bind((0, 0))
+        family = _resolve_family(sock, 'MAC80211_HWSIM')
+        payload = _nla(HWSIM_ATTR_RADIO_NAME,
+                       name.encode() + b'\x00') + _pmsr_support()
+        reply = _request(sock, family, HWSIM_CMD_NEW_RADIO, payload,
+                         seq=2, ack=True)
+        msg_type = struct.unpack_from('HH', reply, 4)[1]
+        if msg_type == NLMSG_ERROR:
+            err = struct.unpack_from('i', reply, 16)[0]
+            if err < 0:
+                raise OSError(-err, 'NEW_RADIO(%s) failed' % name)
+    finally:
+        sock.close()
+
+
+if __name__ == '__main__':          # manual test: python3 -m mn_wifi.hwsim_pmsr <name>
+    import sys
+    create_ftm_radio(sys.argv[1] if len(sys.argv) > 1 else 'phyrewalltest0')
+    print('created FTM-capable radio')

--- a/mn_wifi/hwsim_pmsr.py
+++ b/mn_wifi/hwsim_pmsr.py
@@ -33,9 +33,11 @@ NLM_F_REQUEST = 0x01
 NLM_F_ACK = 0x04
 NLMSG_ERROR = 2
 
-# HT|VHT|HE preambles (bits 1,2,4); 20|40|80 MHz bandwidths (bits 1,2,3)
+# HT|VHT|HE preambles (NL80211_PREAMBLE_* bits 1,2,4)
 _PREAMBLES = (1 << 1) | (1 << 2) | (1 << 4)
-_BANDWIDTHS = (1 << 1) | (1 << 2) | (1 << 3)
+# bandwidths, NL80211_CHAN_WIDTH_* bits: 20=1, 40=2, 80=3, 160=5, 320=13.
+# (320 also needs an EHT/6GHz-capable radio to actually be requested.)
+_BANDWIDTHS = (1 << 1) | (1 << 2) | (1 << 3) | (1 << 5) | (1 << 13)
 
 
 def _nla(atype, payload):

--- a/mn_wifi/module.py
+++ b/mn_wifi/module.py
@@ -7,6 +7,7 @@ from time import sleep
 from subprocess import check_output as co, PIPE, Popen, call, CalledProcessError
 from logging import basicConfig, exception, DEBUG
 from mininet.log import debug, info, error
+from mn_wifi.hwsim_pmsr import create_ftm_radio
 
 
 class Mac80211Hwsim(object):
@@ -17,6 +18,7 @@ class Mac80211Hwsim(object):
     externally_managed = False
     devices_created_dynamically = False
     phyWlans = None
+    ftm = False   # create PMSR/FTM-capable radios (802.11az/mc ranging)
 
     def __init__(self, on_the_fly=False, **params):
         if on_the_fly:
@@ -49,6 +51,7 @@ class Mac80211Hwsim(object):
         :param alt_module: dir of a mac80211_hwsim alternative module
         :params rec_rssi: if we set rssi to hwsim
         """
+        Mac80211Hwsim.ftm = params.pop('ftm', False)
         if rec_rssi:
             self.add_phy_id(nodes)
 
@@ -115,7 +118,15 @@ class Mac80211Hwsim(object):
 
     def create_hwsim(self, n):
         self.get_phys()
-        p = Popen(["hwsim_mgmt", "-c", "-n", self.prefix + ("%02d" % n)],
+        name = self.prefix + ("%02d" % n)
+        if Mac80211Hwsim.ftm:
+            # self-contained: create a PMSR/FTM-capable radio via netlink,
+            # since hwsim_mgmt cannot request the capability. Radios are found
+            # by name afterwards; the id list only needs the right length.
+            create_ftm_radio(name)
+            Mac80211Hwsim.hwsim_ids.append(str(n))
+            return
+        p = Popen(["hwsim_mgmt", "-c", "-n", name],
                   stdin=PIPE, stdout=PIPE, stderr=PIPE, bufsize=-1)
         output, err_out = p.communicate()
         if p.returncode == 0:

--- a/mn_wifi/net.py
+++ b/mn_wifi/net.py
@@ -135,6 +135,7 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
         self.isReplaying = False
         self.reverse = False
         self.alt_module = None
+        self.ftm = False   # create PMSR/FTM-capable radios (802.11az/mc ranging)
         self.mob_check = False
         self.mob_model = None
         self.ac_method = ac_method
@@ -1644,7 +1645,7 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
         nodes, nradios = self.count_ifaces()
         if nodes:
             Mac80211Hwsim(nodes=nodes, nradios=nradios,
-                          alt_module=self.alt_module, **params)
+                          alt_module=self.alt_module, ftm=self.ftm, **params)
 
         if self.ifb: Mac80211Hwsim.load_ifb(nradios)
 


### PR DESCRIPTION
Hi @ramonfontes, 

This is the mininet-wifi counterpart for https://github.com/ramonfontes/wmediumd/pull/18

It adds the `net.ftm` (default `False`), once `True` it creates FTM-capable radios by sending HWSIM_ATTR_PMSR_SUPPORT (20/40/80/160/320 MHz).