### PR TITLE
Add PMSR/FTM ranging-error-model knobs to the wmediumd config

### DIFF
--- a/mn_wifi/link.py
+++ b/mn_wifi/link.py
@@ -1472,7 +1472,9 @@ class wmediumd(object):
         self.configWmediumd(**kwargs)
 
     def configWmediumd(self, wlinks, fading_cof, noise_th, stations,
-                       aps, cars, aircrafts, satellites, ppm, mediums):
+                       aps, cars, aircrafts, satellites, ppm, mediums,
+                       pmsr_sigma=0.0, pmsr_nlos_prob=0.0, pmsr_nlos_bias=0.0,
+                       pmsr_seed=1):
         "Configure wmediumd"
         intfrefs = []
         isnodeaps = []
@@ -1538,7 +1540,9 @@ class wmediumd(object):
             mediums_id_list.append(medium_intf_ids)
         WStarter(intfrefs=intfrefs, links=self.links, pos=self.positions,
                  fading_cof=fading_cof, noise_th=noise_th, txpowers=self.txpowers,
-                 isnodeaps=isnodeaps, ppm=ppm, mediums=mediums_id_list)
+                 isnodeaps=isnodeaps, ppm=ppm, mediums=mediums_id_list,
+                 pmsr_sigma=pmsr_sigma, pmsr_nlos_prob=pmsr_nlos_prob,
+                 pmsr_nlos_bias=pmsr_nlos_bias, pmsr_seed=pmsr_seed)
 
     @staticmethod
     def get_position(pos=None):

--- a/mn_wifi/link.py
+++ b/mn_wifi/link.py
@@ -1474,7 +1474,7 @@ class wmediumd(object):
     def configWmediumd(self, wlinks, fading_cof, noise_th, stations,
                        aps, cars, aircrafts, satellites, ppm, mediums,
                        pmsr_sigma=0.0, pmsr_nlos_prob=0.0, pmsr_nlos_bias=0.0,
-                       pmsr_seed=1):
+                       pmsr_seed=1, pmsr_crlb_alpha=0.0):
         "Configure wmediumd"
         intfrefs = []
         isnodeaps = []
@@ -1542,7 +1542,8 @@ class wmediumd(object):
                  fading_cof=fading_cof, noise_th=noise_th, txpowers=self.txpowers,
                  isnodeaps=isnodeaps, ppm=ppm, mediums=mediums_id_list,
                  pmsr_sigma=pmsr_sigma, pmsr_nlos_prob=pmsr_nlos_prob,
-                 pmsr_nlos_bias=pmsr_nlos_bias, pmsr_seed=pmsr_seed)
+                 pmsr_nlos_bias=pmsr_nlos_bias, pmsr_seed=pmsr_seed,
+                 pmsr_crlb_alpha=pmsr_crlb_alpha)
 
     @staticmethod
     def get_position(pos=None):

--- a/mn_wifi/link.py
+++ b/mn_wifi/link.py
@@ -1474,7 +1474,7 @@ class wmediumd(object):
     def configWmediumd(self, wlinks, fading_cof, noise_th, stations,
                        aps, cars, aircrafts, satellites, ppm, mediums,
                        pmsr_sigma=0.0, pmsr_nlos_prob=0.0, pmsr_nlos_bias=0.0,
-                       pmsr_seed=1, pmsr_crlb_alpha=0.0):
+                       pmsr_seed=1, pmsr_crlb_alpha=0.0, pmsr_brms_ratio=0.0):
         "Configure wmediumd"
         intfrefs = []
         isnodeaps = []
@@ -1543,7 +1543,7 @@ class wmediumd(object):
                  isnodeaps=isnodeaps, ppm=ppm, mediums=mediums_id_list,
                  pmsr_sigma=pmsr_sigma, pmsr_nlos_prob=pmsr_nlos_prob,
                  pmsr_nlos_bias=pmsr_nlos_bias, pmsr_seed=pmsr_seed,
-                 pmsr_crlb_alpha=pmsr_crlb_alpha)
+                 pmsr_crlb_alpha=pmsr_crlb_alpha, pmsr_brms_ratio=pmsr_brms_ratio)
 
     @staticmethod
     def get_position(pos=None):

--- a/mn_wifi/net.py
+++ b/mn_wifi/net.py
@@ -136,6 +136,12 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
         self.reverse = False
         self.alt_module = None
         self.ftm = False   # create PMSR/FTM-capable radios (802.11az/mc ranging)
+        # PMSR/FTM ranging-error model (written to the wmediumd config;
+        # 0 = exact geometry). Set per bandwidth/environment.
+        self.pmsr_sigma = 0.0        # LOS jitter std dev [m]
+        self.pmsr_nlos_prob = 0.0    # probability of an NLOS measurement
+        self.pmsr_nlos_bias = 0.0    # mean of the exponential NLOS bias [m]
+        self.pmsr_seed = 1
         self.mob_check = False
         self.mob_model = None
         self.ac_method = ac_method
@@ -1571,7 +1577,9 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
         wmediumd(wlinks=self.wlinks, fading_cof=self.fading_cof,
                  noise_th=self.noise_th, stations=self.stations,
                  aps=self.aps, cars=self.cars, aircrafts=self.aircrafts,
-                 satellites=self.satellites, ppm=ppm, mediums=self.initial_mediums)
+                 satellites=self.satellites, ppm=ppm, mediums=self.initial_mediums,
+                 pmsr_sigma=self.pmsr_sigma, pmsr_nlos_prob=self.pmsr_nlos_prob,
+                 pmsr_nlos_bias=self.pmsr_nlos_bias, pmsr_seed=self.pmsr_seed)
 
     def start_wmediumd_802154(self):
         wmediumd_802154(wlinks=self.wlinks, fading_cof=self.fading_cof,

--- a/mn_wifi/net.py
+++ b/mn_wifi/net.py
@@ -142,6 +142,7 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
         self.pmsr_nlos_prob = 0.0    # probability of an NLOS measurement
         self.pmsr_nlos_bias = 0.0    # mean of the exponential NLOS bias [m]
         self.pmsr_seed = 1
+        self.pmsr_crlb_alpha = 0.0   # >0: derive LOS sigma from ToA CRLB (bw+SNR)
         self.mob_check = False
         self.mob_model = None
         self.ac_method = ac_method
@@ -1579,7 +1580,8 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
                  aps=self.aps, cars=self.cars, aircrafts=self.aircrafts,
                  satellites=self.satellites, ppm=ppm, mediums=self.initial_mediums,
                  pmsr_sigma=self.pmsr_sigma, pmsr_nlos_prob=self.pmsr_nlos_prob,
-                 pmsr_nlos_bias=self.pmsr_nlos_bias, pmsr_seed=self.pmsr_seed)
+                 pmsr_nlos_bias=self.pmsr_nlos_bias, pmsr_seed=self.pmsr_seed,
+                 pmsr_crlb_alpha=self.pmsr_crlb_alpha)
 
     def start_wmediumd_802154(self):
         wmediumd_802154(wlinks=self.wlinks, fading_cof=self.fading_cof,

--- a/mn_wifi/net.py
+++ b/mn_wifi/net.py
@@ -1576,6 +1576,10 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
         self.mob_object = program(self.cars, self.aps, **kwargs)
 
     def start_wmediumd(self):
+        if (self.pmsr_sigma or self.pmsr_nlos_prob or self.pmsr_crlb_alpha) \
+                and self.wmediumd_mode != interference:
+            warn('*** Warning: the PMSR/FTM ranging-error model is only '
+                 'written in interference mode; net.pmsr_* will be ignored.\n')
         wmediumd(wlinks=self.wlinks, fading_cof=self.fading_cof,
                  noise_th=self.noise_th, stations=self.stations,
                  aps=self.aps, cars=self.cars, aircrafts=self.aircrafts,

--- a/mn_wifi/net.py
+++ b/mn_wifi/net.py
@@ -143,6 +143,7 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
         self.pmsr_nlos_bias = 0.0    # mean of the exponential NLOS bias [m]
         self.pmsr_seed = 1
         self.pmsr_crlb_alpha = 0.0   # >0: derive LOS sigma from ToA CRLB (bw+SNR)
+        self.pmsr_brms_ratio = 0.0   # B_rms/B for the CRLB; 0 = wmediumd default
         self.mob_check = False
         self.mob_model = None
         self.ac_method = ac_method
@@ -1581,7 +1582,8 @@ class Mininet_wifi(Mininet, Mininet_IoT, Mininet_WWAN, Mininet_btvirt):
                  satellites=self.satellites, ppm=ppm, mediums=self.initial_mediums,
                  pmsr_sigma=self.pmsr_sigma, pmsr_nlos_prob=self.pmsr_nlos_prob,
                  pmsr_nlos_bias=self.pmsr_nlos_bias, pmsr_seed=self.pmsr_seed,
-                 pmsr_crlb_alpha=self.pmsr_crlb_alpha)
+                 pmsr_crlb_alpha=self.pmsr_crlb_alpha,
+                 pmsr_brms_ratio=self.pmsr_brms_ratio)
 
     def start_wmediumd_802154(self):
         wmediumd_802154(wlinks=self.wlinks, fading_cof=self.fading_cof,

--- a/mn_wifi/wmediumdConnector.py
+++ b/mn_wifi/wmediumdConnector.py
@@ -122,8 +122,10 @@ class set_interference(object):
         configstr += '\n\t);\n\tfading_coefficient = %d;' % fading_cof
         configstr += '\n\tnoise_threshold = %d;' % noise_th
         # PMSR/FTM two-state ranging-error model (only when enabled)
-        if kwargs.get('pmsr_sigma') or kwargs.get('pmsr_nlos_prob'):
+        if (kwargs.get('pmsr_sigma') or kwargs.get('pmsr_nlos_prob')
+                or kwargs.get('pmsr_crlb_alpha')):
             configstr += '\n\tpmsr_sigma_m = %.4f;' % kwargs.get('pmsr_sigma', 0.0)
+            configstr += '\n\tpmsr_crlb_alpha = %.4f;' % kwargs.get('pmsr_crlb_alpha', 0.0)
             configstr += '\n\tpmsr_nlos_prob = %.4f;' % kwargs.get('pmsr_nlos_prob', 0.0)
             configstr += '\n\tpmsr_nlos_bias_m = %.4f;' % kwargs.get('pmsr_nlos_bias', 0.0)
             configstr += '\n\tpmsr_seed = %d;' % kwargs.get('pmsr_seed', 1)

--- a/mn_wifi/wmediumdConnector.py
+++ b/mn_wifi/wmediumdConnector.py
@@ -121,6 +121,12 @@ class set_interference(object):
                 posX, posY, posZ)
         configstr += '\n\t);\n\tfading_coefficient = %d;' % fading_cof
         configstr += '\n\tnoise_threshold = %d;' % noise_th
+        # PMSR/FTM two-state ranging-error model (only when enabled)
+        if kwargs.get('pmsr_sigma') or kwargs.get('pmsr_nlos_prob'):
+            configstr += '\n\tpmsr_sigma_m = %.4f;' % kwargs.get('pmsr_sigma', 0.0)
+            configstr += '\n\tpmsr_nlos_prob = %.4f;' % kwargs.get('pmsr_nlos_prob', 0.0)
+            configstr += '\n\tpmsr_nlos_bias_m = %.4f;' % kwargs.get('pmsr_nlos_bias', 0.0)
+            configstr += '\n\tpmsr_seed = %d;' % kwargs.get('pmsr_seed', 1)
         configstr += '\n\tisnodeaps = ('
         first_isnodeap = True
         for isnodeap in isnodeaps:

--- a/mn_wifi/wmediumdConnector.py
+++ b/mn_wifi/wmediumdConnector.py
@@ -129,6 +129,9 @@ class set_interference(object):
             configstr += '\n\tpmsr_nlos_prob = %.4f;' % kwargs.get('pmsr_nlos_prob', 0.0)
             configstr += '\n\tpmsr_nlos_bias_m = %.4f;' % kwargs.get('pmsr_nlos_bias', 0.0)
             configstr += '\n\tpmsr_seed = %d;' % kwargs.get('pmsr_seed', 1)
+            # B_rms/B is a divisor in the CRLB; leave wmediumd's default unless set
+            if kwargs.get('pmsr_brms_ratio'):
+                configstr += '\n\tpmsr_brms_ratio = %.4f;' % kwargs['pmsr_brms_ratio']
         configstr += '\n\tisnodeaps = ('
         first_isnodeap = True
         for isnodeap in isnodeaps:


### PR DESCRIPTION
Hi @ramonfontes,

This is the mininet-wifi counterpart for https://github.com/ramonfontes/wmediumd/pull/19. 

It writes the FTM ranging-error model to the `model` section of the generated wmediumd config, next to `noise_threshold` and `fading_coefficient`, from `net.pmsr_sigma` / `pmsr_nlos_prob` / `pmsr_nlos_bias` / `pmsr_seed` / `pmsr_crlb_alpha` / `pmsr_brms_ratio` (all default `0` = exact geometry, so nothing changes unless set).

The knobs only apply in interference mode, a warning is printed otherwise.